### PR TITLE
feat(kata-110): add EventBridge Basics kata -- Rules, Targets & Sched…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -525,9 +525,9 @@ The following katas are planned for the CloudKata library. All are open for comm
 | [kata-106](./katas/kata-106-cloudwatch-basics/) | CloudWatch Basics — Billing Alarm & Alerting | 100 | Depth | CloudWatch | Published |
 | [kata-107](./katas/kata-107-sqs-basics/) | SQS Basics — Queues, Visibility & Dead-Letter Queues | 100 | Depth | SQS | Published |
 | [kata-108](./katas/kata-108-ec2-basics/)  | EC2 Basics — Instances, Security Groups & Key Pairs | 100 | Depth | EC2 | Published |
-| kata-109 | SSM Parameter Store — Parameters, Types & Versioning | 100 | Depth | SSM | Open |
-| kata-110 | EventBridge Basics — Rules, Targets & Scheduling | 100 | Depth | EventBridge | Open |
-| kata-111 | Secrets Manager Basics — Secrets & Access | 100 | Depth | Secrets Manager | Open |
+| kata-109 | SSM Parameter Store — Parameters, Types & Versioning | 100 | Depth | SSM | Assigned |
+| [kata-110](./katas/kata-110-eventbridge-basics/) | EventBridge Basics — Rules, Targets & Scheduling | 100 | Depth | EventBridge | Published |
+| kata-111 | Secrets Manager Basics — Secrets & Access | 100 | Depth | Secrets Manager | In-Progress |
 
 ### 200 Level Kata
 

--- a/katas/kata-110-eventbridge-basics/HINTS.md
+++ b/katas/kata-110-eventbridge-basics/HINTS.md
@@ -1,0 +1,228 @@
+# kata-110 Hints -- EventBridge Basics: Rules, Targets & Scheduling
+
+> ⚠️ **Spoiler warning.** Each hint section reveals progressively more detail.
+> Try to solve each requirement on your own before opening a hint. The learning
+> is in the struggle.
+
+---
+
+## How to use these hints
+
+Hints are organized by requirement number matching the README. Each requirement
+has up to three levels:
+
+- **Hint 1** -- a nudge in the right direction
+- **Hint 2** -- more specific guidance
+- **Hint 3** -- the exact approach (near-solution level)
+
+---
+
+## Requirement 1 -- SNS Topic
+
+<details>
+<summary>Hint 1 -- Where to find SNS</summary>
+
+SNS topics are managed in the Amazon SNS console. Search for "SNS" in the
+AWS console navigation bar. From the SNS dashboard, select **Topics** in
+the left panel and then click **Create topic**.
+
+</details>
+
+<details>
+<summary>Hint 2 -- Topic type</summary>
+
+When creating a topic you will be asked to choose between Standard and FIFO.
+Standard topics support high throughput and at-least-once delivery. FIFO topics
+guarantee ordering and exactly-once delivery but have throughput limits. For
+this kata, choose **Standard**.
+
+</details>
+
+<details>
+<summary>Hint 3 -- Exact configuration</summary>
+
+- **Type:** Standard
+- **Topic name:** `kata-110-AlertTopic` (must be exact -- the validator checks this name)
+- **Tags:** Add `Project = CloudKata` and `Kata = kata-110`
+
+Leave all other settings at their defaults. You do not need to add any
+subscriptions for this kata -- the validator only checks that the topic
+exists and has the correct resource policy.
+
+</details>
+
+---
+
+## Requirement 2 -- EventBridge Rule
+
+<details>
+<summary>Hint 1 -- Where to find EventBridge rules</summary>
+
+Rules are managed in the Amazon EventBridge console. Search for "EventBridge"
+in the AWS console navigation bar. From the EventBridge dashboard, select
+**Rules** under **Buses** in the left panel. Make sure the event bus selector
+at the top shows **default** before creating your rule.
+
+</details>
+
+<details>
+<summary>Hint 2 -- Schedule expression syntax</summary>
+
+EventBridge supports two schedule expression formats: `rate` expressions and
+`cron` expressions. A rate expression uses the format `rate(value unit)` where
+unit is `minute`, `minutes`, `hour`, `hours`, `day`, or `days`. For example,
+`rate(5 minutes)` fires every five minutes. Note that `minute` (singular) is
+only valid for a value of 1 -- use `minutes` (plural) for values greater than 1.
+
+</details>
+
+<details>
+<summary>Hint 3 -- Exact configuration</summary>
+
+- **Event bus:** `default`
+- **Rule name:** `kata-110-ScheduledRule` (must be exact)
+- **Rule type:** Schedule
+- **Schedule expression:** `rate(5 minutes)` (must be exact -- the validator checks this string)
+- **State:** Enabled
+- **Tags:** Add `Project = CloudKata` and `Kata = kata-110`
+
+The validator checks the schedule expression as a literal string match, so
+`rate(5 minutes)` and `rate(5 minute)` are not equivalent -- use the plural
+form.
+
+</details>
+
+---
+
+## Requirement 3 -- Rule Target
+
+<details>
+<summary>Hint 1 -- Adding a target to a rule</summary>
+
+After creating the rule you can add targets from the rule detail page under
+the **Targets** tab, or you can add the target during rule creation in the
+wizard. The target is the resource EventBridge will invoke each time the rule
+fires. For this kata the target is the SNS topic you created in Requirement 1.
+
+</details>
+
+<details>
+<summary>Hint 2 -- SNS topic policy for EventBridge</summary>
+
+EventBridge uses resource-based policies to publish to SNS topics -- it does
+not use an IAM execution role for this. You need to add a policy statement
+directly to the SNS topic that grants the `events.amazonaws.com` service
+principal permission to call `sns:Publish` on your topic. Without this policy,
+EventBridge will fail silently -- the rule fires but no message is delivered.
+
+To add the policy, go to the SNS console, select `kata-110-AlertTopic`,
+open the **Access policy** tab, and edit the policy document to add the
+required statement alongside the existing default statement.
+
+</details>
+
+<details>
+<summary>Hint 3 -- Exact configuration</summary>
+
+**Target settings:**
+- **Target ID:** `kata-110-AlertTopicTarget` (must be exact -- the validator checks this)
+- **Target ARN:** the ARN of `kata-110-AlertTopic`
+- **RoleArn:** do not set -- SNS targets use resource-based policies, not IAM roles
+
+**SNS topic policy statement to add:**
+
+```json
+{
+  "Sid": "AllowEventBridgePublish",
+  "Effect": "Allow",
+  "Principal": {
+    "Service": "events.amazonaws.com"
+  },
+  "Action": "sns:Publish",
+  "Resource": "<ARN of kata-110-AlertTopic>",
+  "Condition": {
+    "ArnLike": {
+      "aws:SourceArn": "arn:aws:events:<region>:<account-id>:rule/kata-110-ScheduledRule"
+    }
+  }
+}
+```
+
+Replace `<ARN of kata-110-AlertTopic>`, `<region>`, and `<account-id>` with
+your actual values. Add this statement to the existing `Statement` array in
+the topic's access policy -- do not replace the default statement.
+
+</details>
+
+---
+
+## General Troubleshooting
+
+<details>
+<summary>Check 1 failing -- SNS topic not found</summary>
+
+The validator looks up the topic by searching for an ARN ending in
+`:kata-110-AlertTopic`. Two common causes: (1) the topic was created in a
+different region -- SNS topics are regional, so verify your CloudShell session
+and your topic are in the same region; (2) the name has a typo or different
+capitalisation -- names are case-sensitive.
+
+</details>
+
+<details>
+<summary>Check 2 failing -- EventBridge rule not found</summary>
+
+The validator calls `describe-rule` by exact name on the default event bus.
+Verify the rule name is exactly `kata-110-ScheduledRule` (case-sensitive) and
+that it was created on the **default** event bus, not a custom bus.
+
+</details>
+
+<details>
+<summary>Check 3 failing -- wrong schedule expression</summary>
+
+The validator checks the schedule expression as a literal string. The expected
+value is `rate(5 minutes)` -- including the space, the plural `minutes`, and
+no extra characters. Open the rule in the EventBridge console and confirm or
+correct the schedule expression.
+
+</details>
+
+<details>
+<summary>Check 5 failing -- target not set</summary>
+
+The rule exists but `kata-110-AlertTopic` is not listed as a target. Go to
+EventBridge → Rules → select `kata-110-ScheduledRule` → **Targets** tab →
+**Add target** → select SNS topic → select `kata-110-AlertTopic` → set the
+target ID to `kata-110-AlertTopicTarget` → save.
+
+</details>
+
+<details>
+<summary>Check 6 failing -- topic policy missing EventBridge permission</summary>
+
+The SNS topic does not have a policy statement granting `events.amazonaws.com`
+permission to `sns:Publish`. Go to SNS → Topics → select `kata-110-AlertTopic`
+→ **Access policy** tab → **Edit** → add the statement shown in Requirement 3,
+Hint 3. Make sure you are adding to the `Statement` array, not replacing the
+entire policy.
+
+</details>
+
+---
+
+## Still stuck?
+
+The complete working solution is in [solution.yml](./solution.yml).
+
+Deploy it with:
+
+```bash
+aws cloudformation deploy \
+  --template-file solution.yml \
+  --stack-name kata-110-solution
+```
+
+Then re-run `validate.sh`. A correctly deployed solution should score 6/6.
+Study the solution to understand what you missed, then tear it down and try
+again from scratch.

--- a/katas/kata-110-eventbridge-basics/README.md
+++ b/katas/kata-110-eventbridge-basics/README.md
@@ -1,0 +1,185 @@
+---
+id: kata-110
+title: "EventBridge Basics -- Rules, Targets & Scheduling"
+level: 100
+type: depth
+services:
+  - eventbridge
+  - sns
+tags:
+  - eventbridge
+  - sns
+  - scheduling
+  - depth
+  - beginner
+estimated_time: 30 minutes
+estimated_cost: "$0.00 - $0.01"
+author: Your Name
+github: https://github.com/fakhtar
+---
+
+# kata-110 -- EventBridge Basics: Rules, Targets & Scheduling
+
+## Overview
+
+In this kata you will build a foundational Amazon EventBridge setup covering the
+three core concepts of event-driven scheduling: a scheduled rule, an SNS topic
+as the target, and the resource-based policy that permits EventBridge to publish
+to it. You will configure a rule on the default event bus that fires on a fixed
+rate and routes invocations to an SNS topic, giving you a working end-to-end
+scheduled notification pipeline.
+
+This kata uses only the default EventBridge event bus. No custom event bus is
+required.
+
+---
+
+## Prerequisites
+
+- An active AWS account
+- Access to AWS CloudShell
+- IAM permissions to create and manage EventBridge rules and SNS topics
+
+---
+
+## Cost & Time
+
+| | |
+|---|---|
+| ⏱ Estimated Time | ~30 minutes |
+| 💰 Estimated Cost | ~$0.00 - $0.01 |
+
+> ⚠️ **Cost Warning:** These are estimates only. Actual costs depend on your AWS
+> region, account tier, and how quickly you complete the kata. If you leave
+> infrastructure running beyond the kata session, costs will continue to
+> accumulate. All charges are your responsibility. Always run cleanup
+> instructions when finished.
+
+---
+
+## Requirements
+
+Build the following infrastructure in your AWS account. All resource names must
+follow the naming convention: `kata-110-ResourceName`
+
+You are given a spec, not a tutorial. Use the AWS Console, CLI, IaC, or any
+tools you choose to meet these requirements. Consult the AWS documentation, use
+AI assistants, or search the web -- whatever you would use on the job.
+
+---
+
+### Requirement 1 -- SNS Topic
+
+Create an SNS standard topic with the following configuration:
+
+- **Topic name:** `kata-110-AlertTopic`
+- **Tags:** `Project: CloudKata` and `Kata: kata-110`
+
+---
+
+### Requirement 2 -- EventBridge Rule
+
+Create a scheduled EventBridge rule with the following configuration:
+
+- **Rule name:** `kata-110-ScheduledRule`
+- **Schedule:** Fires every 5 minutes
+- **State:** Enabled
+- **Tags:** `Project: CloudKata` and `Kata: kata-110`
+
+---
+
+### Requirement 3 -- Rule Target
+
+Configure the EventBridge rule to deliver to the SNS topic:
+
+- **Target:** `kata-110-AlertTopic`
+- **Target ID:** `kata-110-AlertTopicTarget`
+
+EventBridge requires permission to publish to the SNS topic. The SNS topic must
+have a resource-based policy that grants EventBridge publish access, scoped to
+this rule.
+
+---
+
+## Running the Validator
+
+Once you have built the required infrastructure, open AWS CloudShell and upload
+or copy `validate.sh` to your CloudShell environment, then run:
+
+```bash
+sed -i 's/\r//' validate.sh
+chmod +x validate.sh
+./validate.sh
+```
+
+The validator checks your live AWS infrastructure and reports a score. A fully
+passing result looks like this:
+
+```
+==================================================
+ CloudKata Validator -- kata-110
+ EventBridge Basics: Rules, Targets & Scheduling
+==================================================
+
+✅ PASS -- SNS topic 'kata-110-AlertTopic' exists
+✅ PASS -- EventBridge rule 'kata-110-ScheduledRule' exists
+✅ PASS -- Rule schedule expression is 'rate(5 minutes)'
+✅ PASS -- Rule state is ENABLED
+✅ PASS -- Rule target is set to 'kata-110-AlertTopic'
+✅ PASS -- SNS topic policy grants EventBridge publish permission
+
+==================================================
+ Results: 6/6 checks passed (100%)
+==================================================
+
+ 🎉 Perfect score! All kata-110 requirements met.
+```
+
+---
+
+## Cleanup
+
+Always clean up your resources when you are finished.
+
+### Step 1 -- Delete CloudFormation stacks (if applicable)
+
+If you deployed `solution.yml`, delete that stack first via CloudFormation.
+Stack deletion will remove the EventBridge rule and SNS topic automatically.
+
+- Go to the AWS CloudFormation console
+- Select the stack created for this kata
+- Choose **Delete** and wait for deletion to complete
+
+Via CLI:
+```bash
+aws cloudformation delete-stack --stack-name kata-110-solution
+aws cloudformation wait stack-delete-complete --stack-name kata-110-solution
+```
+
+### Step 2 -- Manual Cleanup
+
+If you created resources manually, delete in this order:
+
+1. **Remove the EventBridge rule target** -- a rule with targets cannot be
+   deleted until all targets are removed first. Go to EventBridge → Rules,
+   select `kata-110-ScheduledRule`, open the **Targets** tab, select the
+   target, and choose **Remove**.
+2. **Delete the EventBridge rule** -- once all targets are removed, select
+   `kata-110-ScheduledRule` and choose **Delete**.
+3. **Delete the SNS topic** -- go to SNS → Topics, select
+   `kata-110-AlertTopic`, and choose **Delete**.
+
+### Step 3 -- Verify in the console
+
+Go to EventBridge → Rules and confirm `kata-110-ScheduledRule` no longer
+exists. Go to SNS → Topics and confirm `kata-110-AlertTopic` no longer exists.
+
+---
+
+## Hints & Solution
+
+Stuck? Refer to [HINTS.md](./HINTS.md) for progressive hints without full
+spoilers.
+
+The complete solution is available in [solution.yml](./solution.yml). Deploying
+`solution.yml` and re-running `validate.sh` should produce a score of 100%.

--- a/katas/kata-110-eventbridge-basics/solution.yml
+++ b/katas/kata-110-eventbridge-basics/solution.yml
@@ -1,0 +1,77 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "CloudKata kata-110 - EventBridge Basics: Rules, Targets & Scheduling. Deploys kata-110-AlertTopic (SNS), kata-110-ScheduledRule (EventBridge), and the SNS topic policy granting EventBridge publish access."
+
+# ==============================================================================
+# Resources
+# ==============================================================================
+Resources:
+
+  # ----------------------------------------------------------------------------
+  # SNS Topic -- kata-110-AlertTopic
+  # Standard SNS topic used as the EventBridge rule target.
+  # ----------------------------------------------------------------------------
+  KataAlertTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: kata-110-AlertTopic
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-110
+
+  # ----------------------------------------------------------------------------
+  # SNS Topic Policy -- grants EventBridge permission to publish to the topic.
+  #
+  # For SNS targets, EventBridge uses resource-based policies, not IAM roles.
+  # Do NOT set RoleArn on the EventBridge target -- doing so can cause delivery
+  # failures for SNS targets. The policy here grants events.amazonaws.com the
+  # sns:Publish action, scoped to this rule ARN via aws:SourceArn.
+  # ----------------------------------------------------------------------------
+  KataAlertTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref KataAlertTopic
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowEventBridgePublish
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref KataAlertTopic
+            Condition:
+              ArnLike:
+                aws:SourceArn: !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/kata-110-ScheduledRule"
+
+  # ----------------------------------------------------------------------------
+  # EventBridge Rule -- kata-110-ScheduledRule
+  # Fires every 5 minutes on the default event bus and delivers to the SNS topic.
+  # No RoleArn is specified on the target -- SNS uses resource-based policy above.
+  # ----------------------------------------------------------------------------
+  KataScheduledRule:
+    Type: AWS::Events::Rule
+    DependsOn: KataAlertTopicPolicy
+    Properties:
+      Name: kata-110-ScheduledRule
+      Description: "CloudKata kata-110 - fires every 5 minutes and publishes to kata-110-AlertTopic"
+      ScheduleExpression: "rate(5 minutes)"
+      State: ENABLED
+      Targets:
+        - Id: kata-110-AlertTopicTarget
+          Arn: !Ref KataAlertTopic
+
+# ==============================================================================
+# Outputs
+# ==============================================================================
+Outputs:
+
+  TopicArn:
+    Description: ARN of the SNS topic
+    Value: !Ref KataAlertTopic
+
+  RuleArn:
+    Description: ARN of the EventBridge rule
+    Value: !GetAtt KataScheduledRule.Arn

--- a/katas/kata-110-eventbridge-basics/validate.sh
+++ b/katas/kata-110-eventbridge-basics/validate.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+# ==============================================================================
+# CloudKata Validator -- kata-110
+# EventBridge Basics: Rules, Targets & Scheduling
+# ==============================================================================
+
+TOPIC_NAME="kata-110-AlertTopic"
+RULE_NAME="kata-110-ScheduledRule"
+TARGET_ID="kata-110-AlertTopicTarget"
+EXPECTED_SCHEDULE="rate(5 minutes)"
+
+PASS=0
+FAIL=0
+TOTAL=6
+
+pass() { echo "✅ PASS -- $1"; ((PASS++)); }
+fail() { echo "❌ FAIL -- $1: $2"; ((FAIL++)); }
+
+echo ""
+echo "=================================================="
+echo " CloudKata Validator -- kata-110"
+echo " EventBridge Basics: Rules, Targets & Scheduling"
+echo "=================================================="
+echo ""
+
+# ------------------------------------------------------------------------------
+# Check 1 -- SNS topic exists
+# ------------------------------------------------------------------------------
+echo "Checking SNS topic..."
+TOPIC_ARN=$(aws sns list-topics \
+  --query "Topics[?ends_with(TopicArn, ':${TOPIC_NAME}')].TopicArn" \
+  --output text 2>/dev/null | head -1)
+
+if [ -n "$TOPIC_ARN" ] && [ "$TOPIC_ARN" != "None" ]; then
+  pass "SNS topic '$TOPIC_NAME' exists"
+else
+  fail "SNS topic '$TOPIC_NAME' not found" \
+    "Create an SNS standard topic named exactly '$TOPIC_NAME' in this region"
+  TOPIC_ARN=""
+fi
+
+# ------------------------------------------------------------------------------
+# Check 2 -- EventBridge rule exists
+# ------------------------------------------------------------------------------
+echo "Checking EventBridge rule..."
+RULE_JSON=$(aws events describe-rule \
+  --name "$RULE_NAME" \
+  --output json 2>/dev/null)
+
+RULE_FOUND=$(echo "$RULE_JSON" | jq -r '.Name // empty' 2>/dev/null)
+
+if [ "$RULE_FOUND" = "$RULE_NAME" ]; then
+  pass "EventBridge rule '$RULE_NAME' exists"
+else
+  fail "EventBridge rule '$RULE_NAME' not found" \
+    "Create a scheduled EventBridge rule named exactly '$RULE_NAME' on the default event bus"
+  echo ""
+  echo "=================================================="
+  PCT=$(( (PASS * 100) / TOTAL ))
+  echo " Results: $PASS/$TOTAL checks passed ($PCT%)"
+  echo "=================================================="
+  echo " 📖 Keep going -- consult HINTS.md for guidance."
+  echo ""
+  exit 1
+fi
+
+# ------------------------------------------------------------------------------
+# Check 3 -- Rule schedule expression is correct
+# ------------------------------------------------------------------------------
+echo "Checking schedule expression..."
+ACTUAL_SCHEDULE=$(echo "$RULE_JSON" | jq -r '.ScheduleExpression // empty' 2>/dev/null)
+
+if [ "$ACTUAL_SCHEDULE" = "$EXPECTED_SCHEDULE" ]; then
+  pass "Rule schedule expression is '$EXPECTED_SCHEDULE'"
+else
+  fail "Rule schedule expression is '$ACTUAL_SCHEDULE'" \
+    "Expected '$EXPECTED_SCHEDULE' -- update the rule schedule"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 4 -- Rule state is ENABLED
+# ------------------------------------------------------------------------------
+echo "Checking rule state..."
+RULE_STATE=$(echo "$RULE_JSON" | jq -r '.State // empty' 2>/dev/null)
+
+if [ "$RULE_STATE" = "ENABLED" ]; then
+  pass "Rule state is ENABLED"
+else
+  fail "Rule state is '$RULE_STATE'" \
+    "The rule must be in an ENABLED state -- enable it in the EventBridge console"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 5 -- Rule target is the SNS topic
+# ------------------------------------------------------------------------------
+echo "Checking rule target..."
+if [ -n "$TOPIC_ARN" ]; then
+  TARGET_ARN=$(aws events list-targets-by-rule \
+    --rule "$RULE_NAME" \
+    --query "Targets[?Arn=='${TOPIC_ARN}'].Arn" \
+    --output text 2>/dev/null | head -1)
+
+  if [ "$TARGET_ARN" = "$TOPIC_ARN" ]; then
+    pass "Rule target is set to '$TOPIC_NAME'"
+  else
+    fail "Rule target is not set to '$TOPIC_NAME'" \
+      "Add '$TOPIC_NAME' as a target of '$RULE_NAME' with target ID '$TARGET_ID'"
+  fi
+else
+  fail "Cannot check rule target" \
+    "SNS topic '$TOPIC_NAME' was not found -- create it first"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 6 -- SNS topic policy grants EventBridge publish permission
+# ------------------------------------------------------------------------------
+echo "Checking SNS topic policy..."
+if [ -n "$TOPIC_ARN" ]; then
+  POLICY_RAW=$(aws sns get-topic-attributes \
+    --topic-arn "$TOPIC_ARN" \
+    --query 'Attributes.Policy' \
+    --output text 2>/dev/null)
+
+  EB_ALLOWED=$(echo "$POLICY_RAW" | jq -r '
+    .Statement[]
+    | select(
+        (.Effect == "Allow") and
+        (
+          (.Principal.Service == "events.amazonaws.com") or
+          ((.Principal.Service // []) | arrays | any(. == "events.amazonaws.com"))
+        ) and
+        (
+          (.Action == "sns:Publish") or
+          ((.Action // []) | arrays | any(. == "sns:Publish"))
+        )
+      )
+    | .Effect' 2>/dev/null | head -1)
+
+  if [ "$EB_ALLOWED" = "Allow" ]; then
+    pass "SNS topic policy grants EventBridge publish permission"
+  else
+    fail "SNS topic policy does not grant EventBridge publish permission" \
+      "Add a resource-based policy to '$TOPIC_NAME' allowing events.amazonaws.com to sns:Publish"
+  fi
+else
+  fail "Cannot check SNS topic policy" \
+    "SNS topic '$TOPIC_NAME' was not found -- create it first"
+fi
+
+# ------------------------------------------------------------------------------
+# Results
+# ------------------------------------------------------------------------------
+PCT=$(( (PASS * 100) / TOTAL ))
+
+echo ""
+echo "=================================================="
+echo " Results: $PASS/$TOTAL checks passed ($PCT%)"
+echo "=================================================="
+
+if [ "$PASS" -eq "$TOTAL" ]; then
+  echo " 🎉 Perfect score! All kata-110 requirements met."
+elif [ "$PASS" -ge 4 ]; then
+  echo " 🔧 Almost there -- review the failed checks above."
+else
+  echo " 📖 Keep going -- consult HINTS.md for guidance."
+fi
+echo ""


### PR DESCRIPTION
…uling

Introduces kata-110, a level-100 depth kata covering foundational Amazon EventBridge concepts: scheduled rules, SNS targets, and resource-based permission policies.

- katas/kata-110/README.md
- katas/kata-110/validate.sh
- katas/kata-110/solution.yml
- katas/kata-110/HINTS.md

---

Spec-driven requirements across three requirements:

- Requirement 1: Standard SNS topic named kata-110-AlertTopic
- Requirement 2: Scheduled EventBridge rule named kata-110-ScheduledRule, firing every 5 minutes, in ENABLED state -- schedule expression syntax intentionally omitted from the spec and deferred to HINTS.md
- Requirement 3: Rule target pointing to kata-110-AlertTopic with target ID kata-110-AlertTopicTarget, plus a resource-based SNS topic policy granting EventBridge publish access

Includes cost/time estimates, validator usage instructions, three-step cleanup sequence (CloudFormation stack deletion, manual resource deletion, console verification), and links to HINTS.md and solution.yml.

---

6 checks covering all three requirements:

  Check 1 -- SNS topic kata-110-AlertTopic exists (looked up via
             aws sns list-topics with a JMESPath ends_with filter on
             the topic ARN; no get-by-name API exists for SNS)
  Check 2 -- EventBridge rule kata-110-ScheduledRule exists on the
             default event bus (aws events describe-rule); acts as a
             hard gate -- script exits early with partial score if the
             rule is not found, consistent with kata-108 pattern
  Check 3 -- Rule ScheduleExpression is exactly "rate(5 minutes)"
  Check 4 -- Rule State is ENABLED
  Check 5 -- Rule target ARN matches the kata-110-AlertTopic ARN
             (aws events list-targets-by-rule with JMESPath filter)
  Check 6 -- SNS topic policy grants events.amazonaws.com sns:Publish
             permission (aws sns get-topic-attributes, Policy attribute
             parsed with jq; filter handles both string and array shapes
             for Principal.Service and Action, tested against four
             realistic policy shapes before commit)

bash -n syntax check passed. All AWS CLI commands, flags, and response field names verified against official AWS CLI documentation before writing.

---

Three CloudFormation resources:

  KataAlertTopic (AWS::SNS::Topic)
    Standard SNS topic named kata-110-AlertTopic. Tagged Project:
    CloudKata and Kata: kata-110.

  KataAlertTopicPolicy (AWS::SNS::TopicPolicy)
    Resource-based policy granting events.amazonaws.com sns:Publish on
    the topic, scoped via aws:SourceArn condition to the rule ARN. Per
    AWS documentation, SNS targets use resource-based policies only --
    specifying RoleArn on an SNS target can cause delivery failures.

  KataScheduledRule (AWS::Events::Rule)
    Rule named kata-110-ScheduledRule on the default event bus with
    ScheduleExpression "rate(5 minutes)", State ENABLED, and target ID
    kata-110-AlertTopicTarget pointing to KataAlertTopic. DependsOn
    KataAlertTopicPolicy ensures the topic policy exists before
    EventBridge registers the target. No RoleArn on the target.

All resource names, property keys, and allowed values verified against CloudFormation resource schema documentation before writing. No non-ASCII characters in any string fields. YAML structure validated with a CloudFormation-aware parser (intrinsic function constructors registered).

Outputs: TopicArn, RuleArn.

---

Three-level progressive hint system per requirement, spoiler-gated with <details> blocks:

  Requirement 1 -- SNS console navigation, Standard vs FIFO distinction,
                   exact topic name and tag values
  Requirement 2 -- EventBridge console navigation, rate() expression
                   syntax and plural/singular unit rule, exact schedule
                   expression string and case-sensitive rule name
  Requirement 3 -- Target configuration in the EventBridge console,
                   explanation of why resource-based policy is required
                   (EventBridge fires silently if policy is missing),
                   exact JSON policy statement with aws:SourceArn
                   condition scoped to the rule ARN

General troubleshooting section covers all six validator checks with specific remediation steps for each failure mode.

Closes #23 