### PR TITLE
feat(kata-207): add CloudTrail Basics kata -- trails, events & audit …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -540,7 +540,7 @@ The following katas are planned for the CloudKata library. All are open for comm
 | kata-204 | S3 + Lambda — Event Notifications & Triggers | 200 | Breadth | S3, Lambda | Open |
 | kata-205 | Lambda + SQS — Event Source Mapping & Error Handling | 200 | Breadth | Lambda, SQS | Open |
 | kata-206 | RDS Basics — Instances, Subnet Groups & Parameter Groups | 200 | Depth | RDS | Open |
-| kata-207 | CloudTrail Basics — Trails, Events & Audit Logging | 200 | Depth | CloudTrail, S3 | Open |
+| [kata-207](./katas/kata-207-cloudtrail-basics/)  | CloudTrail Basics — Trails, Events & Audit Logging | 200 | Depth | CloudTrail, S3 | Published |
 
 ### 300 Level Kata
 

--- a/katas/kata-207-cloudtrail-basics/HINTS.md
+++ b/katas/kata-207-cloudtrail-basics/HINTS.md
@@ -1,0 +1,262 @@
+# kata-207 Hints -- CloudTrail Basics: Trails, Events & Audit Logging
+
+> ⚠️ **Spoiler warning.** Each hint section reveals progressively more detail.
+> Try to solve each requirement on your own before opening a hint. The learning
+> is in the struggle.
+
+---
+
+## How to use these hints
+
+Hints are organized by requirement number matching the README. Each requirement
+has up to three levels:
+
+- **Hint 1** -- a nudge in the right direction
+- **Hint 2** -- more specific guidance
+- **Hint 3** -- the exact approach (near-solution level)
+
+---
+
+## Requirement 1 -- S3 Bucket
+
+<details>
+<summary>Hint 1 -- Where to create the bucket</summary>
+
+S3 buckets are managed in the Amazon S3 console. Search for "S3" in the AWS
+console navigation bar and click **Create bucket**. The bucket must be created
+in the same region where you will create the trail -- CloudTrail delivers logs
+to buckets in the same region.
+
+</details>
+
+<details>
+<summary>Hint 2 -- Bucket naming and settings</summary>
+
+The bucket name must include your 12-digit AWS account ID as a suffix because
+S3 bucket names are globally unique and this naming pattern prevents collisions.
+You can find your account ID in the top-right corner of the AWS console under
+your account name, or by running `aws sts get-caller-identity` in CloudShell.
+
+Keep all other bucket settings at their defaults -- block public access should
+remain enabled.
+
+</details>
+
+<details>
+<summary>Hint 3 -- Exact configuration</summary>
+
+- **Bucket name:** `kata-207-trail-logs-<your-account-id>` (replace
+  `<your-account-id>` with your 12-digit account ID -- the validator detects
+  this automatically)
+- **Region:** same region as your CloudShell session
+- **Block Public Access:** all four settings enabled (default)
+- **Tags:** add `Project = CloudKata` and `Kata = kata-207`
+
+The bucket needs a resource-based policy before CloudTrail can deliver logs to
+it -- see Requirement 3, Hint 3 for the exact policy statements.
+
+</details>
+
+---
+
+## Requirement 2 -- CloudTrail Trail
+
+<details>
+<summary>Hint 1 -- Where to create the trail</summary>
+
+Trails are managed in the AWS CloudTrail console. Search for "CloudTrail" in
+the AWS console navigation bar. From the CloudTrail dashboard, select **Trails**
+in the left panel and click **Create trail**.
+
+</details>
+
+<details>
+<summary>Hint 2 -- Trail scope and storage</summary>
+
+When creating the trail, you will be asked whether to apply it to all regions
+or to the current region only. For this kata, choose the current region only --
+a single-region trail is sufficient. You will also need to point the trail at
+the S3 bucket you created in Requirement 1. If you have not created the bucket
+yet, do that first -- CloudTrail will validate that the bucket policy grants it
+access before allowing you to save the trail.
+
+</details>
+
+<details>
+<summary>Hint 3 -- Exact configuration</summary>
+
+- **Trail name:** `kata-207-AuditTrail` (must be exact -- the validator checks
+  this name)
+- **Storage location:** use the existing bucket `kata-207-trail-logs-<account-id>`
+- **Log file SSE-KMS encryption:** disabled (not required for this kata)
+- **Log file validation:** optional
+- **Multi-region trail:** no -- single region only
+- **Tags:** add `Project = CloudKata` and `Kata = kata-207`
+
+</details>
+
+---
+
+## Requirement 3 -- Management Event Logging
+
+<details>
+<summary>Hint 1 -- What management events are</summary>
+
+Management events (also called control plane operations) capture API calls that
+create, modify, or delete AWS resources -- for example, creating an EC2
+instance, attaching an IAM policy, or deleting an S3 bucket. They are distinct
+from data events, which track operations on the contents of resources (such as
+reading or writing S3 objects). CloudTrail trails log management events by
+default when you create a trail through the console.
+
+</details>
+
+<details>
+<summary>Hint 2 -- Read vs Write events and logging state</summary>
+
+Management events are categorised as either Read (describe, list, get) or Write
+(create, update, delete). The validator requires both to be captured, which
+corresponds to the "All" setting in the CloudTrail console under **Management
+events - API activity**. Make sure the trail is also in an active logging state
+-- a trail that exists but is stopped will fail Check 4. Logging state is
+controlled by the **Start logging / Stop logging** toggle on the trail detail
+page.
+
+</details>
+
+<details>
+<summary>Hint 3 -- Exact configuration and bucket policy</summary>
+
+**Event selector settings:**
+- **Management events:** enabled
+- **API activity:** Read and Write (select both)
+
+**Trail state:** logging must be started (the toggle on the trail detail page
+must show "Logging: On").
+
+**S3 bucket policy** -- CloudTrail will not deliver logs without this. Go to
+S3, select your `kata-207-trail-logs-<account-id>` bucket, open the
+**Permissions** tab, and set the bucket policy to the following (replace
+`<account-id>` and `<region>` with your values):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AWSCloudTrailAclCheck",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Action": "s3:GetBucketAcl",
+      "Resource": "arn:aws:s3:::kata-207-trail-logs-<account-id>",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceArn": "arn:aws:cloudtrail:<region>:<account-id>:trail/kata-207-AuditTrail"
+        }
+      }
+    },
+    {
+      "Sid": "AWSCloudTrailWrite",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::kata-207-trail-logs-<account-id>/AWSLogs/<account-id>/*",
+      "Condition": {
+        "StringEquals": {
+          "s3:x-amz-acl": "bucket-owner-full-control",
+          "aws:SourceArn": "arn:aws:cloudtrail:<region>:<account-id>:trail/kata-207-AuditTrail"
+        }
+      }
+    }
+  ]
+}
+```
+
+</details>
+
+---
+
+## General Troubleshooting
+
+<details>
+<summary>Check 1 failing -- S3 bucket not found</summary>
+
+The validator looks for a bucket named `kata-207-trail-logs-<account-id>` using
+your current account ID. Two common causes: (1) the bucket was created in a
+different region -- S3 bucket names are global but the validator uses
+`head-bucket` which is region-aware; (2) the account ID suffix is wrong or
+missing -- verify the exact bucket name in the S3 console.
+
+</details>
+
+<details>
+<summary>Check 2 failing -- bucket policy missing CloudTrail permission</summary>
+
+The bucket exists but its policy does not grant `cloudtrail.amazonaws.com`
+permission to `s3:GetBucketAcl` or `s3:PutObject`. Go to S3, select the
+bucket, open the **Permissions** tab, and add the policy from Requirement 3,
+Hint 3. Make sure you replace all placeholder values with your actual account
+ID and region.
+
+</details>
+
+<details>
+<summary>Check 3 failing -- trail not found</summary>
+
+The validator calls `describe-trails` by exact name. Verify the trail name is
+exactly `kata-207-AuditTrail` (case-sensitive) and that it was created in the
+same region as your CloudShell session. You can confirm the trail's home region
+in the CloudTrail console under the trail's detail page.
+
+</details>
+
+<details>
+<summary>Check 4 failing -- trail not logging</summary>
+
+The trail exists but logging is stopped. Go to CloudTrail, select
+`kata-207-AuditTrail`, and look for the logging toggle near the top of the
+detail page. If it shows "Logging: Off", click **Start logging**.
+
+</details>
+
+<details>
+<summary>Check 5 failing -- wrong S3 bucket</summary>
+
+The trail is configured to deliver logs to a different bucket than
+`kata-207-trail-logs-<account-id>`. Go to CloudTrail, select
+`kata-207-AuditTrail`, click **Edit**, and update the storage location to the
+correct bucket.
+
+</details>
+
+<details>
+<summary>Check 6 failing -- management events not configured</summary>
+
+The trail exists and is logging, but the event selector is not capturing
+management events with ReadWriteType "All". Go to CloudTrail, select
+`kata-207-AuditTrail`, open the **Event history** tab or the trail edit page,
+and under **Management events** ensure both Read and Write are selected.
+
+</details>
+
+---
+
+## Still stuck?
+
+The complete working solution is in [solution.yml](./solution.yml).
+
+Deploy it with:
+
+```bash
+aws cloudformation deploy \
+  --template-file solution.yml \
+  --stack-name kata-207-solution
+```
+
+Then re-run `validate.sh`. A correctly deployed solution should score 6/6.
+Study the solution to understand what you missed, then tear it down and try
+again from scratch.

--- a/katas/kata-207-cloudtrail-basics/README.md
+++ b/katas/kata-207-cloudtrail-basics/README.md
@@ -1,0 +1,194 @@
+---
+id: kata-207
+title: "CloudTrail Basics -- Trails, Events & Audit Logging"
+level: 200
+type: depth
+services:
+  - cloudtrail
+  - s3
+tags:
+  - cloudtrail
+  - s3
+  - audit
+  - logging
+  - depth
+  - intermediate
+estimated_time: 45 minutes
+estimated_cost: "$0.00 - $0.02"
+author: Your Name
+github: https://github.com/fakhtar
+---
+
+# kata-207 -- CloudTrail Basics: Trails, Events & Audit Logging
+
+## Overview
+
+In this kata you will build a foundational AWS CloudTrail setup covering the
+three core components of audit logging: an S3 bucket configured to receive
+CloudTrail log files, a trail that delivers management events to that bucket,
+and the resource-based policy that permits CloudTrail to write to it. You will
+end up with a working end-to-end audit logging pipeline that captures both read
+and write management events across your AWS account.
+
+This kata uses a single-region trail on the default CloudTrail configuration.
+No organisation trail or CloudWatch Logs integration is required.
+
+---
+
+## Prerequisites
+
+- An active AWS account
+- Access to AWS CloudShell
+- IAM permissions to create and manage CloudTrail trails and S3 buckets
+
+---
+
+## Cost & Time
+
+| | |
+|---|---|
+| ⏱ Estimated Time | ~45 minutes |
+| 💰 Estimated Cost | ~$0.00 - $0.02 |
+
+> ⚠️ **Cost Warning:** These are estimates only. Actual costs depend on your AWS
+> region, account tier, and how quickly you complete the kata. If you leave
+> infrastructure running beyond the kata session, costs will continue to
+> accumulate. CloudTrail charges apply for management events beyond the free
+> tier. All charges are your responsibility. Always run cleanup instructions
+> when finished.
+
+---
+
+## Requirements
+
+Build the following infrastructure in your AWS account. All resource names must
+follow the naming convention: `kata-207-ResourceName`
+
+You are given a spec, not a tutorial. Use the AWS Console, CLI, IaC, or any
+tools you choose to meet these requirements. Consult the AWS documentation, use
+AI assistants, or search the web -- whatever you would use on the job.
+
+---
+
+### Requirement 1 -- S3 Bucket
+
+Create an S3 bucket for CloudTrail log delivery with the following
+configuration:
+
+- **Bucket name:** `kata-207-trail-logs-<your-account-id>` (replace
+  `<your-account-id>` with your 12-digit AWS account ID)
+- **Tags:** `Project: CloudKata` and `Kata: kata-207`
+
+The bucket must have a resource-based policy that grants CloudTrail permission
+to deliver log files to it, scoped to your account and trail.
+
+---
+
+### Requirement 2 -- CloudTrail Trail
+
+Create a CloudTrail trail with the following configuration:
+
+- **Trail name:** `kata-207-AuditTrail`
+- **S3 bucket:** the bucket created in Requirement 1
+- **Multi-region trail:** no -- single region only
+- **Tags:** `Project: CloudKata` and `Kata: kata-207`
+
+---
+
+### Requirement 3 -- Management Event Logging
+
+Configure the trail to capture management events:
+
+- **Management events:** enabled
+- **Read/Write events:** All (both Read and Write)
+- **Trail state:** actively logging (not stopped)
+
+---
+
+## Running the Validator
+
+Once you have built the required infrastructure, open AWS CloudShell and upload
+or copy `validate.sh` to your CloudShell environment, then run:
+
+```bash
+sed -i 's/\r//' validate.sh
+chmod +x validate.sh
+./validate.sh
+```
+
+The validator checks your live AWS infrastructure and reports a score. A fully
+passing result looks like this:
+
+```
+==================================================
+ CloudKata Validator -- kata-207
+ CloudTrail Basics: Trails, Events & Audit Logging
+==================================================
+
+✅ PASS -- S3 bucket for log delivery exists
+✅ PASS -- S3 bucket policy grants CloudTrail delivery permission
+✅ PASS -- CloudTrail trail 'kata-207-AuditTrail' exists
+✅ PASS -- Trail is actively logging
+✅ PASS -- Trail delivers logs to the correct S3 bucket
+✅ PASS -- Trail logs management events (Read and Write)
+
+==================================================
+ Results: 6/6 checks passed (100%)
+==================================================
+
+ 🎉 Perfect score! All kata-207 requirements met.
+```
+
+---
+
+## Cleanup
+
+Always clean up your resources when you are finished.
+
+### Step 1 -- Delete CloudFormation stacks (if applicable)
+
+If you deployed `solution.yml`, you must **empty the S3 bucket before deleting
+the stack**. CloudTrail will have delivered log files to the bucket during the
+kata session, and CloudFormation cannot delete a non-empty bucket. Attempting
+to delete the stack without emptying the bucket first will leave the bucket in
+a `DELETE_FAILED` state.
+
+Via CLI:
+```bash
+# Step 1a -- empty the bucket first (replace <account-id> with your account ID)
+aws s3 rm s3://kata-207-trail-logs-<account-id> --recursive
+
+# Step 1b -- then delete the stack
+aws cloudformation delete-stack --stack-name kata-207-solution
+aws cloudformation wait stack-delete-complete --stack-name kata-207-solution
+```
+
+Via console: go to S3, select the `kata-207-trail-logs-*` bucket, choose
+**Empty**, confirm, then go to CloudFormation, select the stack, and choose
+**Delete**.
+
+### Step 2 -- Manual Cleanup
+
+If you created resources manually, delete in this order:
+
+1. **Stop and delete the CloudTrail trail** -- go to CloudTrail → Trails,
+   select `kata-207-AuditTrail`, stop logging, then delete the trail.
+2. **Empty the S3 bucket** -- go to S3, select the `kata-207-trail-logs-*`
+   bucket, and delete all objects (including any log files CloudTrail
+   delivered).
+3. **Delete the S3 bucket** -- once empty, delete the bucket.
+
+### Step 3 -- Verify in the console
+
+Go to CloudTrail → Trails and confirm `kata-207-AuditTrail` no longer exists.
+Go to S3 and confirm the `kata-207-trail-logs-*` bucket no longer exists.
+
+---
+
+## Hints & Solution
+
+Stuck? Refer to [HINTS.md](./HINTS.md) for progressive hints without full
+spoilers.
+
+The complete solution is available in [solution.yml](./solution.yml). Deploying
+`solution.yml` and re-running `validate.sh` should produce a score of 100%.

--- a/katas/kata-207-cloudtrail-basics/solution.yml
+++ b/katas/kata-207-cloudtrail-basics/solution.yml
@@ -1,0 +1,110 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "CloudKata kata-207 - CloudTrail Basics: Trails, Events & Audit Logging. Deploys kata-207-trail-logs-<account-id> (S3), the bucket policy granting CloudTrail delivery access, and kata-207-AuditTrail (CloudTrail) logging management events."
+
+# ==============================================================================
+# Resources
+# ==============================================================================
+Resources:
+
+  # ----------------------------------------------------------------------------
+  # S3 Bucket -- kata-207-trail-logs-<account-id>
+  # Receives CloudTrail log files. Named with the account ID suffix because S3
+  # bucket names are globally unique and CloudTrail requires a unique bucket.
+  # Public access is fully blocked.
+  # ----------------------------------------------------------------------------
+  KataTrailLogsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "kata-207-trail-logs-${AWS::AccountId}"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-207
+
+  # ----------------------------------------------------------------------------
+  # S3 Bucket Policy -- grants CloudTrail permission to deliver log files.
+  #
+  # CloudTrail requires two S3 permissions:
+  #   1. s3:GetBucketAcl  -- CloudTrail checks the bucket ACL before writing.
+  #   2. s3:PutObject     -- CloudTrail writes log files under AWSLogs/<account>.
+  #
+  # Both statements are scoped to the cloudtrail.amazonaws.com service principal
+  # and further restricted with aws:SourceArn to this specific trail. The
+  # PutObject statement uses the s3:x-amz-acl condition required by CloudTrail.
+  # ----------------------------------------------------------------------------
+  KataTrailLogsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref KataTrailLogsBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AWSCloudTrailAclCheck
+            Effect: Allow
+            Principal:
+              Service: cloudtrail.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: !Sub "arn:aws:s3:::kata-207-trail-logs-${AWS::AccountId}"
+            Condition:
+              StringEquals:
+                aws:SourceArn: !Sub "arn:aws:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/kata-207-AuditTrail"
+          - Sid: AWSCloudTrailWrite
+            Effect: Allow
+            Principal:
+              Service: cloudtrail.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub "arn:aws:s3:::kata-207-trail-logs-${AWS::AccountId}/AWSLogs/${AWS::AccountId}/*"
+            Condition:
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
+                aws:SourceArn: !Sub "arn:aws:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/kata-207-AuditTrail"
+
+  # ----------------------------------------------------------------------------
+  # CloudTrail Trail -- kata-207-AuditTrail
+  # Single-region trail that logs all management events (Read and Write) and
+  # delivers log files to the S3 bucket above.
+  #
+  # Notes:
+  #   - IsLogging: true starts logging immediately on stack creation.
+  #   - IsMultiRegionTrail: false keeps this kata single-region only.
+  #   - EventSelectors with IncludeManagementEvents: true and ReadWriteType: All
+  #     explicitly captures both Read and Write management events.
+  #   - DependsOn the bucket policy to ensure CloudTrail can write on creation.
+  # ----------------------------------------------------------------------------
+  KataAuditTrail:
+    Type: AWS::CloudTrail::Trail
+    DependsOn: KataTrailLogsBucketPolicy
+    Properties:
+      TrailName: kata-207-AuditTrail
+      S3BucketName: !Ref KataTrailLogsBucket
+      IsLogging: true
+      IsMultiRegionTrail: false
+      IncludeGlobalServiceEvents: true
+      EnableLogFileValidation: false
+      EventSelectors:
+        - IncludeManagementEvents: true
+          ReadWriteType: All
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-207
+
+# ==============================================================================
+# Outputs
+# ==============================================================================
+Outputs:
+
+  BucketName:
+    Description: Name of the S3 bucket receiving CloudTrail log files
+    Value: !Ref KataTrailLogsBucket
+
+  TrailArn:
+    Description: ARN of the CloudTrail trail
+    Value: !GetAtt KataAuditTrail.Arn

--- a/katas/kata-207-cloudtrail-basics/validate.sh
+++ b/katas/kata-207-cloudtrail-basics/validate.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+
+# ==============================================================================
+# CloudKata Validator -- kata-207
+# CloudTrail Basics: Trails, Events & Audit Logging
+# ==============================================================================
+
+TRAIL_NAME="kata-207-AuditTrail"
+BUCKET_PREFIX="kata-207-trail-logs-"
+
+PASS=0
+FAIL=0
+TOTAL=6
+
+pass() { echo "✅ PASS -- $1"; ((PASS++)); }
+fail() { echo "❌ FAIL -- $1: $2"; ((FAIL++)); }
+
+echo ""
+echo "=================================================="
+echo " CloudKata Validator -- kata-207"
+echo " CloudTrail Basics: Trails, Events & Audit Logging"
+echo "=================================================="
+echo ""
+
+# ------------------------------------------------------------------------------
+# Resolve account ID (used to identify the expected bucket name)
+# ------------------------------------------------------------------------------
+ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text 2>/dev/null)
+EXPECTED_BUCKET="${BUCKET_PREFIX}${ACCOUNT_ID}"
+
+# ------------------------------------------------------------------------------
+# Check 1 -- S3 bucket for log delivery exists
+# ------------------------------------------------------------------------------
+echo "Checking S3 bucket..."
+BUCKET_NAME=""
+if aws s3api head-bucket --bucket "$EXPECTED_BUCKET" > /dev/null 2>&1; then
+  pass "S3 bucket for log delivery exists"
+  BUCKET_NAME="$EXPECTED_BUCKET"
+else
+  # Fallback: search for any bucket matching the prefix in case account ID is
+  # different (e.g. when running across assumed roles)
+  BUCKET_NAME=$(aws s3api list-buckets \
+    --query "Buckets[?starts_with(Name, '${BUCKET_PREFIX}')].Name" \
+    --output text 2>/dev/null | head -1)
+
+  if [ -n "$BUCKET_NAME" ] && [ "$BUCKET_NAME" != "None" ]; then
+    pass "S3 bucket for log delivery exists"
+  else
+    fail "S3 bucket for log delivery not found" \
+      "Create an S3 bucket named '${EXPECTED_BUCKET}' in this region"
+    BUCKET_NAME=""
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 2 -- S3 bucket policy grants CloudTrail delivery permission
+# ------------------------------------------------------------------------------
+echo "Checking S3 bucket policy..."
+if [ -n "$BUCKET_NAME" ]; then
+  BUCKET_POLICY=$(aws s3api get-bucket-policy \
+    --bucket "$BUCKET_NAME" \
+    --query 'Policy' \
+    --output text 2>/dev/null)
+
+  CT_ALLOWED=$(echo "$BUCKET_POLICY" | jq -r '
+    .Statement[]
+    | select(
+        (.Effect == "Allow") and
+        (
+          (.Principal.Service == "cloudtrail.amazonaws.com") or
+          ((.Principal.Service // []) | arrays | any(. == "cloudtrail.amazonaws.com"))
+        ) and
+        (
+          ((.Action == "s3:PutObject") or (.Action == "s3:GetBucketAcl")) or
+          ((.Action // []) | arrays | any(. == "s3:PutObject" or . == "s3:GetBucketAcl"))
+        )
+      )
+    | .Effect' 2>/dev/null | head -1)
+
+  if [ "$CT_ALLOWED" = "Allow" ]; then
+    pass "S3 bucket policy grants CloudTrail delivery permission"
+  else
+    fail "S3 bucket policy does not grant CloudTrail delivery permission" \
+      "Add a bucket policy allowing cloudtrail.amazonaws.com to s3:GetBucketAcl and s3:PutObject"
+  fi
+else
+  fail "Cannot check S3 bucket policy" \
+    "S3 bucket '${EXPECTED_BUCKET}' was not found -- create it first"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 3 -- CloudTrail trail exists
+# ------------------------------------------------------------------------------
+echo "Checking CloudTrail trail..."
+TRAIL_JSON=$(aws cloudtrail describe-trails \
+  --trail-name-list "$TRAIL_NAME" \
+  --output json 2>/dev/null)
+
+TRAIL_FOUND=$(echo "$TRAIL_JSON" | jq -r '.trailList[0].Name // empty' 2>/dev/null)
+
+if [ "$TRAIL_FOUND" = "$TRAIL_NAME" ]; then
+  pass "CloudTrail trail '$TRAIL_NAME' exists"
+  TRAIL_ARN=$(echo "$TRAIL_JSON" | jq -r '.trailList[0].TrailARN // empty' 2>/dev/null)
+  TRAIL_BUCKET=$(echo "$TRAIL_JSON" | jq -r '.trailList[0].S3BucketName // empty' 2>/dev/null)
+else
+  fail "CloudTrail trail '$TRAIL_NAME' not found" \
+    "Create a CloudTrail trail named exactly '$TRAIL_NAME' in this region"
+  TRAIL_ARN=""
+  TRAIL_BUCKET=""
+fi
+
+# ------------------------------------------------------------------------------
+# Check 4 -- Trail is actively logging
+# ------------------------------------------------------------------------------
+echo "Checking trail logging status..."
+if [ -n "$TRAIL_ARN" ]; then
+  IS_LOGGING=$(aws cloudtrail get-trail-status \
+    --name "$TRAIL_ARN" \
+    --query 'IsLogging' \
+    --output text 2>/dev/null)
+
+  if [ "$IS_LOGGING" = "True" ] || [ "$IS_LOGGING" = "true" ]; then
+    pass "Trail is actively logging"
+  else
+    fail "Trail is not actively logging" \
+      "Start logging on '$TRAIL_NAME' -- go to CloudTrail and enable logging for the trail"
+  fi
+else
+  fail "Cannot check trail logging status" \
+    "Trail '$TRAIL_NAME' was not found -- create it first"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 5 -- Trail delivers logs to the correct S3 bucket
+# ------------------------------------------------------------------------------
+echo "Checking trail S3 bucket configuration..."
+if [ -n "$TRAIL_BUCKET" ] && [ -n "$BUCKET_NAME" ]; then
+  if [ "$TRAIL_BUCKET" = "$BUCKET_NAME" ]; then
+    pass "Trail delivers logs to the correct S3 bucket"
+  else
+    fail "Trail is delivering to bucket '$TRAIL_BUCKET'" \
+      "Expected bucket '$BUCKET_NAME' -- update the trail to deliver to the correct bucket"
+  fi
+elif [ -n "$TRAIL_ARN" ]; then
+  fail "Cannot verify trail S3 bucket" \
+    "S3 bucket '$EXPECTED_BUCKET' was not found -- create it first"
+else
+  fail "Cannot check trail S3 bucket" \
+    "Trail '$TRAIL_NAME' was not found -- create it first"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 6 -- Trail logs management events (Read and Write)
+# ------------------------------------------------------------------------------
+echo "Checking event selectors..."
+if [ -n "$TRAIL_ARN" ]; then
+  SELECTORS_JSON=$(aws cloudtrail get-event-selectors \
+    --trail-name "$TRAIL_ARN" \
+    --output json 2>/dev/null)
+
+  # Check basic event selectors first
+  MGMT_ALL=$(echo "$SELECTORS_JSON" | jq -r '
+    .EventSelectors[]?
+    | select(
+        (.IncludeManagementEvents == true) and
+        (.ReadWriteType == "All")
+      )
+    | "found"' 2>/dev/null | head -1)
+
+  if [ "$MGMT_ALL" = "found" ]; then
+    pass "Trail logs management events (Read and Write)"
+  else
+    # Check advanced event selectors -- management events are logged by default
+    # when advanced selectors are used, indicated by a Management category selector
+    ADV_MGMT=$(echo "$SELECTORS_JSON" | jq -r '
+      .AdvancedEventSelectors[]?
+      | select(
+          .FieldSelectors[]?
+          | select(.Field == "eventCategory" and (.Equals[]? == "Management"))
+        )
+      | "found"' 2>/dev/null | head -1)
+
+    if [ "$ADV_MGMT" = "found" ]; then
+      pass "Trail logs management events (Read and Write)"
+    else
+      fail "Trail does not log management events with ReadWriteType All" \
+        "Configure the trail event selectors to include management events with Read and Write"
+    fi
+  fi
+else
+  fail "Cannot check event selectors" \
+    "Trail '$TRAIL_NAME' was not found -- create it first"
+fi
+
+# ------------------------------------------------------------------------------
+# Results
+# ------------------------------------------------------------------------------
+PCT=$(( (PASS * 100) / TOTAL ))
+
+echo ""
+echo "=================================================="
+echo " Results: $PASS/$TOTAL checks passed ($PCT%)"
+echo "=================================================="
+
+if [ "$PASS" -eq "$TOTAL" ]; then
+  echo " 🎉 Perfect score! All kata-207 requirements met."
+elif [ "$PASS" -ge 4 ]; then
+  echo " 🔧 Almost there -- review the failed checks above."
+else
+  echo " 📖 Keep going -- consult HINTS.md for guidance."
+fi
+echo ""


### PR DESCRIPTION
…logging

Introduces kata-207, a depth-level kata covering the three core components of AWS CloudTrail: an S3 bucket configured for log delivery, a trail that captures management events, and the resource-based bucket policy that permits CloudTrail to write to it.

---

- Written to spec level only -- requirements describe WHAT to build, no implementation detail (no CLI syntax, no console navigation, no policy JSON in requirements).
- Three requirements: S3 bucket (with account-ID suffix naming), CloudTrail trail (single-region, named kata-207-AuditTrail), and management event logging (Read and Write, trail actively logging).
- Validator expected output block showing all 6 checks passing at 100%.
- Cleanup section with ordered manual steps (stop trail, empty bucket, delete bucket) and CloudFormation stack deletion instructions.
- Step 1 of CloudFormation cleanup warns explicitly that the S3 bucket must be emptied before stack deletion. CloudTrail delivers log files during the session and CloudFormation cannot delete a non-empty bucket, leaving KataTrailLogsBucket in DELETE_FAILED without this step. Includes ordered CLI commands (aws s3 rm --recursive then delete-stack) and a console alternative.

---

Six checks against live AWS infrastructure:

- Check 1: S3 bucket exists -- uses `aws s3api head-bucket` against the expected bucket name (kata-207-trail-logs-<account-id>, resolved via `aws sts get-caller-identity`). Falls back to `list-buckets` prefix search for assumed-role scenarios. Uses direct `if aws s3api head-bucket ...; then` pattern rather than capturing exit code via `$?` after command substitution, which is unreliable. Stdout redirected to /dev/null to suppress JSON response body leaking to terminal.
- Check 2: S3 bucket policy grants CloudTrail delivery permission -- fetches policy via `get-bucket-policy`, parses with jq to find a statement where Principal.Service is cloudtrail.amazonaws.com and Action includes s3:GetBucketAcl or s3:PutObject. Handles both string and array forms of Principal.Service and Action.
- Check 3: Trail exists -- uses `aws cloudtrail describe-trails --trail-name-list`. `--include-shadow-trails false` intentionally omitted; including it caused the trail to be filtered from results in CloudShell even when the trail was deployed and CREATE_COMPLETE, because the flag restricts results to trails whose home region strictly matches the current API endpoint region. Extracts TrailARN and S3BucketName for use in downstream checks.
- Check 4: Trail is actively logging -- uses `aws cloudtrail get-trail-status --name <arn>` and checks IsLogging == true. Accepts both "True" and "true" to handle CLI output variation.
- Check 5: Trail delivers to the correct S3 bucket -- compares S3BucketName from describe-trails against the bucket found in Check 1.
- Check 6: Management events Read and Write -- uses `aws cloudtrail get-event-selectors`. Checks basic event selectors first (IncludeManagementEvents == true and ReadWriteType == "All"), then falls back to advanced event selectors (eventCategory field selector with Equals == "Management") to handle both selector types.

Results block scores PASS/TOTAL with percentage, and prints contextual messaging at three thresholds (6/6, >=4, <4).

---

Three resources:

- KataTrailLogsBucket (AWS::S3::Bucket): named kata-207-trail-logs-${AWS::AccountId} using Sub pseudo-parameter. All four PublicAccessBlockConfiguration settings enabled. Tagged Project=CloudKata, Kata=kata-207.
- KataTrailLogsBucketPolicy (AWS::S3::BucketPolicy): two statements -- AWSCloudTrailAclCheck grants cloudtrail.amazonaws.com s3:GetBucketAcl on the bucket; AWSCloudTrailWrite grants s3:PutObject on the AWSLogs path with s3:x-amz-acl bucket-owner-full-control condition. Both statements scoped with aws:SourceArn to the specific trail ARN following AWS security best practice.
- KataAuditTrail (AWS::CloudTrail::Trail): named kata-207-AuditTrail, single-region (IsMultiRegionTrail: false), IsLogging: true so logging starts immediately on stack creation. EventSelectors with IncludeManagementEvents: true and ReadWriteType: All. DependsOn: KataTrailLogsBucketPolicy ensures the policy exists before CloudTrail validates bucket access during trail creation. Tagged Project=CloudKata, Kata=kata-207.

Outputs: BucketName and TrailArn.

---

Three requirements, each with three progressive hint levels:

- Requirement 1 (S3 bucket): console location, naming rationale and how to find account ID, exact bucket name and settings including tags.
- Requirement 2 (trail): console location, single-region scope and dependency on bucket existing first, exact trail name and settings.
- Requirement 3 (management events): explanation of what management events are vs data events, Read/Write distinction and logging state toggle, exact event selector settings and full bucket policy JSON with placeholders.

Troubleshooting section covers all six validator checks by number with specific remediation steps for each failure mode. Closes with solution deploy instructions and encouragement to study then rebuild from scratch.

closes #29 