### PR TITLE
feat: add kata-203 — API Gateway + Lambda: REST API & Proxy Integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -536,11 +536,11 @@ The following katas are planned for the CloudKata library. All are open for comm
 | kata-200 | Amazon Connect Basics — Instance, Hours of Operation & Queues | 200 | Depth | Connect | Open |
 | [kata-201](./katas/kata-201-dynamodb-core/) | DynamoDB Core — Tables, Keys, Indexes & Capacity Modes | 200 | Depth | DynamoDB | Published |
 | [kata-202](./katas/kata-202-lexv2-advanced/) | Amazon Lex V2 Advanced — Versioning, Aliases & Lambda Fulfillment | 200 | Depth | Lex V2, Lambda | Published |
-| kata-203 | API Gateway + Lambda — REST API & Proxy Integration | 200 | Breadth | API Gateway, Lambda | Open |
+| [kata-203](./katas/kata-207-cloudtrail-basics/)   | API Gateway + Lambda — REST API & Proxy Integration | 200 | Breadth | API Gateway, Lambda | Open |
 | kata-204 | S3 + Lambda — Event Notifications & Triggers | 200 | Breadth | S3, Lambda | Open |
 | kata-205 | Lambda + SQS — Event Source Mapping & Error Handling | 200 | Breadth | Lambda, SQS | Open |
 | kata-206 | RDS Basics — Instances, Subnet Groups & Parameter Groups | 200 | Depth | RDS | Open |
-| [kata-207](./katas/kata-207-cloudtrail-basics/)  | CloudTrail Basics — Trails, Events & Audit Logging | 200 | Depth | CloudTrail, S3 | Published |
+| [kata-207](./katas/kata-203-api-gateway-lambda-rest/)  | CloudTrail Basics — Trails, Events & Audit Logging | 200 | Depth | CloudTrail, S3 | Published |
 
 ### 300 Level Kata
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -536,11 +536,11 @@ The following katas are planned for the CloudKata library. All are open for comm
 | kata-200 | Amazon Connect Basics — Instance, Hours of Operation & Queues | 200 | Depth | Connect | Open |
 | [kata-201](./katas/kata-201-dynamodb-core/) | DynamoDB Core — Tables, Keys, Indexes & Capacity Modes | 200 | Depth | DynamoDB | Published |
 | [kata-202](./katas/kata-202-lexv2-advanced/) | Amazon Lex V2 Advanced — Versioning, Aliases & Lambda Fulfillment | 200 | Depth | Lex V2, Lambda | Published |
-| [kata-203](./katas/kata-207-cloudtrail-basics/)   | API Gateway + Lambda — REST API & Proxy Integration | 200 | Breadth | API Gateway, Lambda | Open |
+| [kata-203](./katas/kata-203-api-gateway-lambda-rest/)   | API Gateway + Lambda — REST API & Proxy Integration | 200 | Breadth | API Gateway, Lambda | Open |
 | kata-204 | S3 + Lambda — Event Notifications & Triggers | 200 | Breadth | S3, Lambda | Open |
 | kata-205 | Lambda + SQS — Event Source Mapping & Error Handling | 200 | Breadth | Lambda, SQS | Open |
 | kata-206 | RDS Basics — Instances, Subnet Groups & Parameter Groups | 200 | Depth | RDS | Open |
-| [kata-207](./katas/kata-203-api-gateway-lambda-rest/)  | CloudTrail Basics — Trails, Events & Audit Logging | 200 | Depth | CloudTrail, S3 | Published |
+| [kata-207](./katas/kata-207-cloudtrail-basics/)  | CloudTrail Basics — Trails, Events & Audit Logging | 200 | Depth | CloudTrail, S3 | Published |
 
 ### 300 Level Kata
 

--- a/katas/kata-203-api-gateway-lambda-rest/HINTS.md
+++ b/katas/kata-203-api-gateway-lambda-rest/HINTS.md
@@ -1,0 +1,352 @@
+# kata-203 Hints — API Gateway + Lambda: REST API & Proxy Integration
+
+> ⚠️ **Spoiler warning.** Each hint section reveals progressively more detail.
+> Try to solve each requirement on your own before opening a hint. The learning
+> is in the struggle.
+
+---
+
+## How to use these hints
+
+Hints are organized by requirement number matching the README. Each requirement
+has up to three levels:
+
+- **Hint 1** — a nudge in the right direction
+- **Hint 2** — more specific guidance
+- **Hint 3** — the exact approach (near-solution level)
+
+---
+
+## Requirement 1 — Lambda Function
+
+<details>
+<summary>Hint 1 — What the function needs</summary>
+
+A Lambda function needs two things to exist: code and an execution role. The
+role controls what the function is allowed to do inside AWS. Even a function
+that only returns a static response needs permission to write its logs somewhere.
+Think about what AWS service Lambda uses for logging and what permissions that
+requires.
+
+</details>
+
+<details>
+<summary>Hint 2 — The execution role</summary>
+
+Lambda writes logs to Amazon CloudWatch Logs. The AWS managed policy
+`AWSLambdaBasicExecutionRole` grants exactly the permissions needed for this —
+no more. Attach it to an IAM role whose trust policy allows `lambda.amazonaws.com`
+to assume it. That role is then passed to the function.
+
+The function code is provided in the README. Use Python 3.12 as the runtime.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact configuration</summary>
+
+- **Function name:** `kata-203-HandlerFunction`
+- **Runtime:** Python 3.12
+- **Handler:** `index.handler` (if using CloudFormation inline code, the file
+  is automatically named `index.py`, so the handler identifier must start
+  with `index`)
+- **Role:** an IAM role with `AWSLambdaBasicExecutionRole` attached and a trust
+  relationship allowing `lambda.amazonaws.com` to assume it
+
+In the Lambda console, choose **Author from scratch**, set the runtime to
+Python 3.12, and paste the function code from the README into the inline
+editor. You can create the execution role directly in the console during
+function creation by choosing **Create a new role with basic Lambda permissions**.
+
+</details>
+
+---
+
+## Requirement 2 — REST API
+
+<details>
+<summary>Hint 1 — REST API vs HTTP API</summary>
+
+API Gateway offers two main API types: REST APIs (v1) and HTTP APIs (v2). They
+look similar in the console but behave differently and use different CLI
+namespaces. This kata uses a REST API. When creating via the console, choose
+**REST API** — not HTTP API, not WebSocket.
+
+</details>
+
+<details>
+<summary>Hint 2 — Creating the API</summary>
+
+In the API Gateway console, choose **Create API** then select **REST API**
+(the non-private variant). Choose **New API** and set the name to
+`kata-203-OrderAPI`. The endpoint type can be left as Regional. No other
+settings are required at creation time.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact name</summary>
+
+The API must be named exactly `kata-203-OrderAPI`. The validator finds the API
+by name using `aws apigateway get-rest-apis`, so capitalisation and hyphens
+must match exactly.
+
+</details>
+
+---
+
+## Requirement 3 — Resource and Method
+
+<details>
+<summary>Hint 1 — Resources and methods in API Gateway</summary>
+
+In a REST API, a resource represents a URL path segment. A method sits on a
+resource and defines how HTTP verbs (GET, POST, etc.) are handled. To expose
+`GET /orders`, you need a resource at the path `/orders` and a GET method on
+that resource.
+
+</details>
+
+<details>
+<summary>Hint 2 — Creating the resource and method</summary>
+
+In the API Gateway console, select your API, go to **Resources**, and create
+a new resource with the path segment `orders` under the root `/`. Then select
+that resource and create a method by choosing **Create method** and selecting
+`GET` as the method type.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact path</summary>
+
+The resource path must be `/orders` — a single segment directly under the root.
+The validator checks for this exact path using `aws apigateway get-resources`.
+The GET method must be on that resource specifically, not on the root or any
+other path.
+
+If you are using CloudFormation, the `PathPart` property takes just the segment
+name without the leading slash: `orders`, not `/orders`.
+
+</details>
+
+---
+
+## Requirement 4 — Lambda Proxy Integration
+
+<details>
+<summary>Hint 1 — What proxy integration means</summary>
+
+API Gateway supports two modes for Lambda integration. In a custom (non-proxy)
+integration, API Gateway transforms the request and response using mapping
+templates. In a proxy integration, API Gateway passes the entire HTTP request
+to Lambda as a structured event and returns Lambda's response object directly
+to the client — no mapping templates needed. The function is responsible for
+returning a well-formed response with `statusCode`, `headers`, and `body`.
+
+</details>
+
+<details>
+<summary>Hint 2 — Wiring the integration</summary>
+
+When configuring the GET method, choose **Lambda function** as the integration
+type and enable the **Lambda proxy integration** toggle. Point it at
+`kata-203-HandlerFunction`. API Gateway will prompt you to add a resource-based
+permission so it can invoke the function — accept this prompt.
+
+If you decline or skip the permission step, the integration will be wired but
+invocations will fail with a permissions error. The validator checks that the
+integration type is `AWS_PROXY` and that the URI references the correct function.
+
+</details>
+
+<details>
+<summary>Hint 3 — CloudFormation integration properties</summary>
+
+In CloudFormation, the `Integration` block on `AWS::ApiGateway::Method` needs:
+
+```yaml
+Integration:
+  Type: AWS_PROXY
+  IntegrationHttpMethod: POST
+  Uri: !Sub
+    - "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FunctionArn}/invocations"
+    - FunctionArn: !GetAtt HandlerFunction.Arn
+```
+
+`IntegrationHttpMethod` must be `POST` for Lambda integrations — this is the
+method API Gateway uses internally to call Lambda, regardless of the
+client-facing HTTP method.
+
+You also need a `AWS::Lambda::Permission` resource to allow API Gateway to
+invoke the function:
+
+```yaml
+LambdaInvokePermission:
+  Type: AWS::Lambda::Permission
+  Properties:
+    FunctionName: !GetAtt HandlerFunction.Arn
+    Action: lambda:InvokeFunction
+    Principal: apigateway.amazonaws.com
+    SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${OrderApi}/*/*/*"
+```
+
+</details>
+
+---
+
+## Requirement 5 — Deployment and Stage
+
+<details>
+<summary>Hint 1 — Why deployment is a separate step</summary>
+
+In API Gateway REST APIs, changes to resources and methods are not live until
+you deploy them. A deployment is a snapshot of your API configuration. A stage
+is a named reference to a deployment — it is the URL prefix that callers use.
+Until you deploy, the endpoint does not exist and cannot be invoked.
+
+</details>
+
+<details>
+<summary>Hint 2 — Deploying in the console</summary>
+
+In the API Gateway console, go to your API and choose **Deploy API** from the
+**Actions** menu (or the **Deploy** button in the Resources view). When prompted,
+create a new stage named `prod`. After deployment, the console will show the
+invoke URL — it will look like
+`https://{api-id}.execute-api.{region}.amazonaws.com/prod`.
+
+Append `/orders` to that URL and verify that a GET request returns HTTP 200.
+
+</details>
+
+<details>
+<summary>Hint 3 — CloudFormation deployment</summary>
+
+Use `AWS::ApiGateway::Deployment` with `StageName: prod`. This resource must
+have a `DependsOn` pointing to your method resource — without it, CloudFormation
+may create the deployment before the method exists and fail with:
+`The REST API doesn't contain any methods`.
+
+```yaml
+ApiDeployment:
+  Type: AWS::ApiGateway::Deployment
+  DependsOn: OrdersGetMethod
+  Properties:
+    RestApiId: !Ref OrderApi
+    StageName: prod
+```
+
+</details>
+
+---
+
+## Requirement 6 — Tags
+
+<details>
+<summary>Hint 1 — Tagging both resources</summary>
+
+This kata requires tags on two separate resources: the Lambda function and the
+REST API. Tagging one without the other will cause checks 8 or 9 to fail. Both
+resources must carry the same two tags.
+
+</details>
+
+<details>
+<summary>Hint 2 — Where to add tags in the console</summary>
+
+For the Lambda function: go to the function page, choose **Configuration** →
+**Tags** → **Manage tags**.
+
+For the REST API: go to the API in the API Gateway console, choose
+**Settings** (at the API level, not the stage level) → **Tags** → **Add tag**.
+Alternatively, navigate to the API's stage and add tags there — but note that
+the validator checks tags on the REST API resource itself, not on the stage.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact tag values</summary>
+
+Tags are case-sensitive. The validator checks for these exact values on both
+the Lambda function and the REST API:
+
+- Key: `Project` — Value: `CloudKata`
+- Key: `Kata` — Value: `kata-203`
+
+</details>
+
+---
+
+## General Troubleshooting
+
+<details>
+<summary>Check 5 failing — integration type is not AWS_PROXY</summary>
+
+The validator reads `.methodIntegration.type` from `get-method` and checks for
+`AWS_PROXY`. If you chose **Lambda function** in the console without enabling
+the **Use Lambda Proxy integration** checkbox, the type will be `AWS` instead.
+Delete the method and recreate it with proxy integration enabled, or update the
+integration type via the console under **Method Execution** → **Integration
+Request** → **Integration type**.
+
+</details>
+
+<details>
+<summary>Check 7 failing — endpoint returns non-200</summary>
+
+A non-200 response from the endpoint usually means one of three things. First,
+the Lambda permission is missing — API Gateway cannot invoke the function and
+returns 500. In the console, go to the method's **Integration Request** and
+check that a resource-based policy exists on the function. Second, the function
+code is returning an unexpected status code — verify the code matches what is
+in the README exactly. Third, the API has not been redeployed after a change —
+any change to a method requires a new deployment before it takes effect.
+
+</details>
+
+<details>
+<summary>Check 8 or 9 failing — tags not found</summary>
+
+The validator uses two different APIs for tags. Lambda tags are retrieved with
+`aws lambda list-tags` using the function ARN. API Gateway tags are retrieved
+with `aws apigateway get-tags` using the REST API ARN, which has the format
+`arn:aws:apigateway:{region}::/restapis/{api-id}` — note there is no account ID
+in this ARN. If tags appear in the console but the validator still fails, verify
+that tags are on the correct resource type (the REST API itself, not a stage
+or deployment).
+
+</details>
+
+<details>
+<summary>CloudFormation DependsOn error — REST API has no methods</summary>
+
+If your stack fails with `The REST API doesn't contain any methods`, the
+`AWS::ApiGateway::Deployment` resource was created before the method was ready.
+Add `DependsOn: OrdersGetMethod` (or whatever your method's logical ID is) to
+the deployment resource. CloudFormation does not automatically infer this
+dependency because the deployment references only the RestApi ID, not the method.
+
+</details>
+
+---
+
+## Still stuck?
+
+The complete working solution is in [solution.yml](./solution.yml).
+
+Deploy it with:
+
+```bash
+aws cloudformation deploy \
+  --template-file solution.yml \
+  --stack-name kata-203-solution \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+Note the `--capabilities CAPABILITY_NAMED_IAM` flag — it is required because
+the template creates an IAM role with an explicit name.
+
+Then re-run `validate.sh`. A correctly deployed solution should score 9/9.
+Study the solution to understand what you missed, then tear it down and
+try again from scratch.

--- a/katas/kata-203-api-gateway-lambda-rest/README.md
+++ b/katas/kata-203-api-gateway-lambda-rest/README.md
@@ -1,0 +1,227 @@
+---
+id: kata-203
+title: "API Gateway + Lambda — REST API & Proxy Integration"
+level: 200
+type: breadth
+services:
+  - apigateway
+  - lambda
+tags:
+  - apigateway
+  - lambda
+  - rest-api
+  - proxy-integration
+  - breadth
+  - foundational
+estimated_time: 45 minutes
+estimated_cost: "$0.00"
+author: Faisal Akhtar
+github: https://github.com/fakhtar
+---
+
+# kata-203 — API Gateway + Lambda: REST API & Proxy Integration
+
+## Overview
+
+In this kata you will build a REST API using API Gateway and wire it to a
+Lambda function using proxy integration. You will define an API resource and
+method, connect the integration, deploy the API to a stage, and verify that
+the endpoint returns a valid HTTP response.
+
+This kata covers foundational serverless API concepts: how API Gateway routes
+HTTP requests to Lambda, what proxy integration means and how it differs from
+custom integration, and how deployment stages control which version of an API
+is live.
+
+---
+
+## Prerequisites
+
+- An active AWS account
+- Access to AWS CloudShell
+- IAM permissions to create and manage API Gateway REST APIs, Lambda functions,
+  and IAM roles
+
+---
+
+## Cost & Time
+
+| | |
+|---|---|
+| ⏱ Estimated Time | ~45 minutes |
+| 💰 Estimated Cost | $0.00 |
+
+> ⚠️ **Cost Warning:** These are estimates only. API Gateway and Lambda both
+> have free tier allowances that comfortably cover this kata. All charges are
+> your responsibility. Always run cleanup instructions when finished.
+
+---
+
+## Scenario
+
+You are building the first endpoint of a new order management API. The backend
+team has agreed on a contract: a `GET /orders` endpoint that returns a JSON
+response. Your job is to provision the API infrastructure and wire it to a
+Lambda function that handles the request. The function code is provided — this
+is an infrastructure kata, not a coding kata.
+
+---
+
+## Lambda Function Code
+
+Use the following code when creating `kata-203-HandlerFunction`. The runtime
+must be **Python 3.12**.
+
+```python
+import json
+
+def handler(event, context):
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps({"message": "orders ok"})
+    }
+```
+
+---
+
+## Requirements
+
+Build the following infrastructure in your AWS account. All resource names
+must follow the naming convention: `kata-203-ResourceName`
+
+You are given a spec, not a tutorial. Use the AWS Console, CLI, IaC, or any
+tools you choose to meet these requirements. Consult the AWS documentation,
+use AI assistants, or search the web — whatever you would use on the job.
+
+---
+
+### Requirement 1 — Lambda Function
+
+Create a Lambda function named `kata-203-HandlerFunction` using the code
+and runtime specified above. The function requires an execution role with
+permission to write logs to CloudWatch Logs.
+
+---
+
+### Requirement 2 — REST API
+
+Create a REST API named `kata-203-OrderAPI`.
+
+---
+
+### Requirement 3 — Resource and Method
+
+Under the REST API, create a resource with the path `/orders`. On that
+resource, create a `GET` method.
+
+---
+
+### Requirement 4 — Lambda Proxy Integration
+
+Configure the `GET /orders` method to use Lambda proxy integration pointing
+to `kata-203-HandlerFunction`. API Gateway must have permission to invoke
+the function.
+
+---
+
+### Requirement 5 — Deployment and Stage
+
+Deploy the API to a stage named `prod`. The validator will invoke the
+deployed endpoint and expect a `200` HTTP response.
+
+---
+
+### Requirement 6 — Tags
+
+Tag the Lambda function and the REST API with the standard CloudKata tags:
+
+- `Project: CloudKata`
+- `Kata: kata-203`
+
+---
+
+## Running the Validator
+
+Once you have built the required infrastructure, open AWS CloudShell and
+upload or copy `validate.sh` to your CloudShell environment, then run:
+
+```bash
+sed -i 's/\r//' validate.sh
+chmod +x validate.sh
+./validate.sh
+```
+
+The validator checks your live AWS infrastructure and reports a score.
+A fully passing result looks like this:
+
+```
+==================================================
+ CloudKata Validator — kata-203
+ API Gateway + Lambda: REST API & Proxy Integration
+==================================================
+
+✅ PASS — Lambda function 'kata-203-HandlerFunction' exists
+✅ PASS — REST API 'kata-203-OrderAPI' exists
+✅ PASS — Resource '/orders' exists
+✅ PASS — GET method exists on '/orders'
+✅ PASS — Lambda proxy integration is configured
+✅ PASS — API is deployed to stage 'prod'
+✅ PASS — Endpoint returns HTTP 200
+✅ PASS — Required tags are present on Lambda function
+✅ PASS — Required tags are present on REST API
+
+==================================================
+ Results: 9/9 checks passed (100%)
+==================================================
+
+ 🎉 Perfect score! All kata-203 requirements met.
+```
+
+---
+
+## Cleanup
+
+Always clean up your resources when you are finished.
+
+### Step 1 — Delete CloudFormation stacks (if applicable)
+
+If you deployed `solution.yml`, delete that stack first via CloudFormation.
+
+```bash
+aws cloudformation delete-stack --stack-name kata-203-solution
+aws cloudformation wait stack-delete-complete --stack-name kata-203-solution
+```
+
+### Step 2 — Manual Cleanup
+
+If you created resources manually:
+
+```bash
+# Get the REST API ID
+API_ID=$(aws apigateway get-rest-apis \
+  --query "items[?name=='kata-203-OrderAPI'].id" \
+  --output text)
+
+# Delete the REST API
+aws apigateway delete-rest-api --rest-api-id "$API_ID"
+
+# Delete the Lambda function
+aws lambda delete-function --function-name kata-203-HandlerFunction
+```
+
+### Step 3 — Verify in the console
+
+Confirm that `kata-203-OrderAPI` no longer appears in the API Gateway console
+and that `kata-203-HandlerFunction` no longer appears in the Lambda console.
+
+---
+
+## Hints & Solution
+
+Stuck? Refer to [HINTS.md](./HINTS.md) for progressive hints without full
+spoilers.
+
+The complete solution is available in [solution.yml](./solution.yml).
+Deploying `solution.yml` and re-running `validate.sh` should produce a
+score of 100%.

--- a/katas/kata-203-api-gateway-lambda-rest/solution.yml
+++ b/katas/kata-203-api-gateway-lambda-rest/solution.yml
@@ -1,0 +1,167 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "CloudKata kata-203 - API Gateway + Lambda: REST API and Proxy Integration. Deploys kata-203-HandlerFunction with an execution role, kata-203-OrderAPI with a GET /orders resource using Lambda proxy integration, and deploys to a prod stage."
+
+# ==============================================================================
+# Resources
+# ==============================================================================
+Resources:
+
+  # ----------------------------------------------------------------------------
+  # IAM Execution Role for Lambda
+  #
+  # AWSLambdaBasicExecutionRole grants permission to write logs to CloudWatch
+  # Logs. This is the minimum role required by any Lambda function.
+  # ----------------------------------------------------------------------------
+  HandlerFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: kata-203-HandlerFunctionRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  # ----------------------------------------------------------------------------
+  # Lambda Function — kata-203-HandlerFunction
+  #
+  # Python 3.12 inline function. CloudFormation places ZipFile content in a
+  # file named index.py, so the handler must be index.handler.
+  #
+  # Returns a static JSON response with statusCode 200. This satisfies the
+  # validator's HTTP 200 check when the endpoint is invoked via curl.
+  # ----------------------------------------------------------------------------
+  HandlerFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: kata-203-HandlerFunction
+      Runtime: python3.12
+      Handler: index.handler
+      Role: !GetAtt HandlerFunctionRole.Arn
+      Code:
+        ZipFile: |
+          import json
+
+          def handler(event, context):
+              return {
+                  "statusCode": 200,
+                  "headers": {"Content-Type": "application/json"},
+                  "body": json.dumps({"message": "orders ok"})
+              }
+      Description: "kata-203 handler - returns 200 JSON response for GET /orders"
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-203
+
+  # ----------------------------------------------------------------------------
+  # REST API — kata-203-OrderAPI
+  # ----------------------------------------------------------------------------
+  OrderApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: kata-203-OrderAPI
+      Description: "kata-203 order management REST API"
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-203
+
+  # ----------------------------------------------------------------------------
+  # Resource — /orders
+  #
+  # PathPart is the last segment only (orders, not /orders).
+  # ParentId points to the API root resource via RootResourceId.
+  # ----------------------------------------------------------------------------
+  OrdersResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref OrderApi
+      ParentId: !GetAtt OrderApi.RootResourceId
+      PathPart: orders
+
+  # ----------------------------------------------------------------------------
+  # Method — GET /orders with Lambda proxy integration
+  #
+  # AuthorizationType: NONE — open access, no IAM or Cognito required.
+  #
+  # Integration:
+  #   Type: AWS_PROXY — Lambda proxy integration. API Gateway passes the full
+  #   request to Lambda and returns the function's response verbatim.
+  #
+  #   IntegrationHttpMethod: POST — Lambda invocations always use POST at the
+  #   API Gateway-to-Lambda level, regardless of the client-facing HTTP method.
+  #
+  #   Uri: the Lambda invocation ARN in the form:
+  #   arn:aws:apigateway:{region}:lambda:path/2015-03-31/functions/{functionArn}/invocations
+  # ----------------------------------------------------------------------------
+  OrdersGetMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      RestApiId: !Ref OrderApi
+      ResourceId: !Ref OrdersResource
+      HttpMethod: GET
+      AuthorizationType: NONE
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub
+          - "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FunctionArn}/invocations"
+          - FunctionArn: !GetAtt HandlerFunction.Arn
+
+  # ----------------------------------------------------------------------------
+  # Lambda Resource Policy — allow API Gateway to invoke the function
+  #
+  # Principal: apigateway.amazonaws.com
+  # SourceArn scoped to this API and all stages/methods using a wildcard.
+  # Using /* /* /* (any stage, any method, any resource) avoids tight coupling
+  # to the stage name and is the recommended pattern for REST APIs.
+  # ----------------------------------------------------------------------------
+  LambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt HandlerFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${OrderApi}/*/*/*"
+
+  # ----------------------------------------------------------------------------
+  # Deployment — deploys the API to the prod stage
+  #
+  # DependsOn: OrdersGetMethod is required. Without it, CloudFormation may
+  # attempt to create the deployment before the method exists, causing:
+  # "The REST API doesn't contain any methods."
+  # ----------------------------------------------------------------------------
+  ApiDeployment:
+    Type: AWS::ApiGateway::Deployment
+    DependsOn: OrdersGetMethod
+    Properties:
+      RestApiId: !Ref OrderApi
+      StageName: prod
+      Description: "kata-203 prod deployment"
+
+# ==============================================================================
+# Outputs
+# ==============================================================================
+Outputs:
+  FunctionName:
+    Description: Name of the Lambda function
+    Value: !Ref HandlerFunction
+
+  FunctionArn:
+    Description: ARN of the Lambda function
+    Value: !GetAtt HandlerFunction.Arn
+
+  ApiId:
+    Description: ID of the REST API
+    Value: !Ref OrderApi
+
+  ApiEndpoint:
+    Description: Invoke URL for the prod stage GET /orders endpoint
+    Value: !Sub "https://${OrderApi}.execute-api.${AWS::Region}.amazonaws.com/prod/orders"

--- a/katas/kata-203-api-gateway-lambda-rest/validate.sh
+++ b/katas/kata-203-api-gateway-lambda-rest/validate.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+
+# ==============================================================================
+# CloudKata Validator — kata-203
+# API Gateway + Lambda: REST API & Proxy Integration
+# ==============================================================================
+
+FUNCTION_NAME="kata-203-HandlerFunction"
+API_NAME="kata-203-OrderAPI"
+RESOURCE_PATH="/orders"
+HTTP_METHOD="GET"
+STAGE_NAME="prod"
+
+PASS=0
+FAIL=0
+
+pass() { echo "✅ PASS — $1"; ((PASS++)); }
+fail() { echo "❌ FAIL — $1"; ((FAIL++)); }
+
+echo ""
+echo "=================================================="
+echo " CloudKata Validator — kata-203"
+echo " API Gateway + Lambda: REST API & Proxy Integration"
+echo "=================================================="
+echo ""
+
+# ------------------------------------------------------------------------------
+# Check 1 — Lambda function exists (hard gate)
+# ------------------------------------------------------------------------------
+echo "Checking Lambda function..."
+FUNCTION_JSON=$(aws lambda get-function \
+  --function-name "$FUNCTION_NAME" \
+  --query 'Configuration' \
+  --output json 2>/dev/null)
+
+if [ -z "$FUNCTION_JSON" ] || [ "$FUNCTION_JSON" = "null" ]; then
+  echo "❌ FAIL — Lambda function '$FUNCTION_NAME' not found. Cannot continue."
+  echo ""
+  echo "=================================================="
+  echo " Results: 0/9 checks passed (0%)"
+  echo "=================================================="
+  exit 1
+fi
+pass "Lambda function '$FUNCTION_NAME' exists"
+
+FUNCTION_ARN=$(echo "$FUNCTION_JSON" | jq -r '.FunctionArn')
+
+# ------------------------------------------------------------------------------
+# Check 2 — REST API exists (hard gate for remaining checks)
+# ------------------------------------------------------------------------------
+echo "Checking REST API..."
+API_ID=$(aws apigateway get-rest-apis \
+  --query "items[?name=='$API_NAME'].id" \
+  --output text 2>/dev/null)
+
+if [ -z "$API_ID" ] || [ "$API_ID" = "None" ]; then
+  fail "REST API '$API_NAME' not found"
+  # Fail all remaining API-dependent checks
+  fail "Resource '$RESOURCE_PATH' could not be checked — API not found"
+  fail "GET method could not be checked — API not found"
+  fail "Lambda proxy integration could not be checked — API not found"
+  fail "Stage '$STAGE_NAME' could not be checked — API not found"
+  fail "Endpoint HTTP 200 could not be checked — API not found"
+  fail "Required tags could not be checked on REST API — API not found"
+  echo ""
+  # Still run Lambda tag check (Check 8)
+  echo "Checking Lambda function tags..."
+  LAMBDA_TAGS=$(aws lambda list-tags \
+    --resource "$FUNCTION_ARN" \
+    --output json 2>/dev/null)
+  LAMBDA_PROJECT=$(echo "$LAMBDA_TAGS" | jq -r '.Tags.Project // empty' 2>/dev/null)
+  LAMBDA_KATA=$(echo "$LAMBDA_TAGS" | jq -r '.Tags.Kata // empty' 2>/dev/null)
+  if [ "$LAMBDA_PROJECT" = "CloudKata" ] && [ "$LAMBDA_KATA" = "kata-203" ]; then
+    pass "Required tags are present on Lambda function"
+  else
+    fail "Missing or incorrect tags on Lambda function"
+  fi
+  PCT=$(( (PASS * 100) / 9 ))
+  echo ""
+  echo "=================================================="
+  echo " Results: $PASS/9 checks passed ($PCT%)"
+  echo "=================================================="
+  echo " 📖 Keep going — consult HINTS.md for guidance."
+  echo ""
+  exit 1
+fi
+pass "REST API '$API_NAME' exists"
+
+# Build the region for constructing ARNs
+REGION=$(aws configure get region 2>/dev/null)
+if [ -z "$REGION" ]; then
+  REGION=$(aws ec2 describe-availability-zones \
+    --query 'AvailabilityZones[0].RegionName' \
+    --output text 2>/dev/null)
+fi
+
+# ------------------------------------------------------------------------------
+# Check 3 — Resource /orders exists
+# ------------------------------------------------------------------------------
+echo "Checking resource '$RESOURCE_PATH'..."
+RESOURCE_JSON=$(aws apigateway get-resources \
+  --rest-api-id "$API_ID" \
+  --query "items[?path=='$RESOURCE_PATH']" \
+  --output json 2>/dev/null)
+
+RESOURCE_COUNT=$(echo "$RESOURCE_JSON" | jq 'length')
+if [ "$RESOURCE_COUNT" -gt 0 ]; then
+  pass "Resource '$RESOURCE_PATH' exists"
+  RESOURCE_ID=$(echo "$RESOURCE_JSON" | jq -r '.[0].id')
+else
+  fail "Resource '$RESOURCE_PATH' not found on the REST API"
+  RESOURCE_ID=""
+fi
+
+# ------------------------------------------------------------------------------
+# Check 4 — GET method exists on /orders
+# ------------------------------------------------------------------------------
+echo "Checking GET method..."
+if [ -z "$RESOURCE_ID" ]; then
+  fail "GET method could not be checked — resource '$RESOURCE_PATH' not found"
+  METHOD_JSON=""
+else
+  METHOD_JSON=$(aws apigateway get-method \
+    --rest-api-id "$API_ID" \
+    --resource-id "$RESOURCE_ID" \
+    --http-method "$HTTP_METHOD" \
+    --output json 2>/dev/null)
+
+  if [ -z "$METHOD_JSON" ] || [ "$METHOD_JSON" = "null" ]; then
+    fail "GET method not found on '$RESOURCE_PATH'"
+    METHOD_JSON=""
+  else
+    pass "GET method exists on '$RESOURCE_PATH'"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 5 — Lambda proxy integration is configured
+# ------------------------------------------------------------------------------
+echo "Checking Lambda proxy integration..."
+if [ -z "$METHOD_JSON" ]; then
+  fail "Lambda proxy integration could not be checked — GET method not found"
+else
+  INTEGRATION_TYPE=$(echo "$METHOD_JSON" | jq -r '.methodIntegration.type // empty')
+  INTEGRATION_URI=$(echo "$METHOD_JSON" | jq -r '.methodIntegration.uri // empty')
+
+  # type must be AWS_PROXY and URI must reference the function name
+  if [ "$INTEGRATION_TYPE" = "AWS_PROXY" ] && \
+     echo "$INTEGRATION_URI" | grep -q "$FUNCTION_NAME"; then
+    pass "Lambda proxy integration is configured"
+  else
+    fail "Lambda proxy integration is not configured correctly — check integration type and target function"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 6 — API is deployed to stage 'prod'
+# ------------------------------------------------------------------------------
+echo "Checking stage '$STAGE_NAME'..."
+STAGE_JSON=$(aws apigateway get-stage \
+  --rest-api-id "$API_ID" \
+  --stage-name "$STAGE_NAME" \
+  --output json 2>/dev/null)
+
+if [ -z "$STAGE_JSON" ] || [ "$STAGE_JSON" = "null" ]; then
+  fail "Stage '$STAGE_NAME' not found — the API has not been deployed to '$STAGE_NAME'"
+else
+  pass "API is deployed to stage '$STAGE_NAME'"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 7 — Endpoint returns HTTP 200
+# ------------------------------------------------------------------------------
+echo "Invoking endpoint..."
+if [ -z "$STAGE_JSON" ]; then
+  fail "Endpoint HTTP 200 could not be checked — stage '$STAGE_NAME' not found"
+else
+  ENDPOINT_URL="https://${API_ID}.execute-api.${REGION}.amazonaws.com/${STAGE_NAME}${RESOURCE_PATH}"
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$ENDPOINT_URL" 2>/dev/null)
+
+  if [ "$HTTP_STATUS" = "200" ]; then
+    pass "Endpoint returns HTTP 200"
+  else
+    fail "Endpoint returned HTTP $HTTP_STATUS — expected 200 (URL: $ENDPOINT_URL)"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 8 — Required tags on Lambda function
+# ------------------------------------------------------------------------------
+echo "Checking Lambda function tags..."
+LAMBDA_TAGS=$(aws lambda list-tags \
+  --resource "$FUNCTION_ARN" \
+  --output json 2>/dev/null)
+
+LAMBDA_PROJECT=$(echo "$LAMBDA_TAGS" | jq -r '.Tags.Project // empty' 2>/dev/null)
+LAMBDA_KATA=$(echo "$LAMBDA_TAGS" | jq -r '.Tags.Kata // empty' 2>/dev/null)
+
+if [ "$LAMBDA_PROJECT" = "CloudKata" ] && [ "$LAMBDA_KATA" = "kata-203" ]; then
+  pass "Required tags are present on Lambda function"
+else
+  MISSING=""
+  [ "$LAMBDA_PROJECT" != "CloudKata" ] && MISSING="Project: CloudKata "
+  [ "$LAMBDA_KATA" != "kata-203" ] && MISSING="${MISSING}Kata: kata-203"
+  fail "Missing or incorrect tags on Lambda function: $MISSING"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 9 — Required tags on REST API
+# ------------------------------------------------------------------------------
+echo "Checking REST API tags..."
+API_ARN="arn:aws:apigateway:${REGION}::/restapis/${API_ID}"
+API_TAGS=$(aws apigateway get-tags \
+  --resource-arn "$API_ARN" \
+  --output json 2>/dev/null)
+
+API_PROJECT=$(echo "$API_TAGS" | jq -r '.tags.Project // empty' 2>/dev/null)
+API_KATA=$(echo "$API_TAGS" | jq -r '.tags.Kata // empty' 2>/dev/null)
+
+if [ "$API_PROJECT" = "CloudKata" ] && [ "$API_KATA" = "kata-203" ]; then
+  pass "Required tags are present on REST API"
+else
+  MISSING=""
+  [ "$API_PROJECT" != "CloudKata" ] && MISSING="Project: CloudKata "
+  [ "$API_KATA" != "kata-203" ] && MISSING="${MISSING}Kata: kata-203"
+  fail "Missing or incorrect tags on REST API: $MISSING"
+fi
+
+# ------------------------------------------------------------------------------
+# Results
+# ------------------------------------------------------------------------------
+PCT=$(( (PASS * 100) / 9 ))
+
+echo ""
+echo "=================================================="
+echo " Results: $PASS/9 checks passed ($PCT%)"
+echo "=================================================="
+
+if [ "$PASS" -eq 9 ]; then
+  echo " 🎉 Perfect score! All kata-203 requirements met."
+elif [ "$PASS" -ge 6 ]; then
+  echo " 🔧 Almost there — review the failed checks above."
+else
+  echo " 📖 Keep going — consult HINTS.md for guidance."
+fi
+echo ""


### PR DESCRIPTION
Introduces kata-203, a breadth-level 200 kata covering REST API construction with API Gateway and Lambda proxy integration. All four required files are included: README.md, validate.sh, solution.yml, and HINTS.md.

- Creating a REST API with API Gateway (REST/v1, not HTTP/v2)
- Defining a resource (/orders) and attaching a GET method
- Wiring Lambda proxy integration (AWS_PROXY) vs custom integration
- Understanding IntegrationHttpMethod: POST for Lambda regardless of client-facing verb
- Granting API Gateway invoke permission via Lambda resource policy
- Deploying an API to a named stage (prod) and invoking the live endpoint
- Tagging both Lambda and API Gateway resources independently

Spec-level requirements only. Lambda function code is provided inline so learners are not blocked on Python — this is an infrastructure kata. Nine checks are defined matching the validator output exactly. Cleanup covers both CloudFormation stack deletion and manual resource removal paths.

Nine checks covering the full deployment chain:
  1. Lambda function exists (hard gate — exits on failure)
  2. REST API exists (hard gate for API-dependent checks)
  3. /orders resource exists on the API
  4. GET method exists on /orders
  5. Integration type is AWS_PROXY and URI references the correct function
  6. prod stage exists (via get-stage)
  7. Live endpoint returns HTTP 200 (curl invocation)
  8. Lambda function carries required tags (lambda list-tags → .Tags.Key)
  9. REST API carries required tags (apigateway get-tags → .tags.Key)

Key implementation notes:
- Lambda tags use aws lambda list-tags returning {"Tags": {}} flat object
- API Gateway tags use aws apigateway get-tags returning {"tags": {}} flat object with lowercase key — different from Lambda's capitalised Tags
- API GW REST API ARN has no account ID: arn:aws:apigateway:{region}::/restapis/{id}
- Region resolved from aws configure get region with ec2 fallback
- bash -n syntax check passes clean

Six resources:
  - AWS::IAM::Role (HandlerFunctionRole) with AWSLambdaBasicExecutionRole
  - AWS::Lambda::Function (kata-203-HandlerFunction) using python3.12 ZipFile inline — handler is index.handler as CFN names the file index.py
  - AWS::ApiGateway::RestApi (kata-203-OrderAPI)
  - AWS::ApiGateway::Resource (/orders, PathPart: orders — no leading slash)
  - AWS::ApiGateway::Method (GET, AWS_PROXY, IntegrationHttpMethod: POST)
  - AWS::Lambda::Permission (Principal: apigateway.amazonaws.com, SourceArn scoped with /*/* /* wildcard per AWS recommendation)
  - AWS::ApiGateway::Deployment (StageName: prod, DependsOn: OrdersGetMethod — required to avoid "no methods" error)

Deploy requires --capabilities CAPABILITY_NAMED_IAM due to explicit role name.

Three-level progressive hints for all six requirements. Troubleshooting sections cover the four most common failure modes:
  - Integration type AWS vs AWS_PROXY (check 5)
  - Missing Lambda permission causing 500 (check 7)
  - Tag API mismatch between Lambda and API Gateway (checks 8/9)
  - DependsOn omission causing deployment creation race (CloudFormation)

Still-stuck section includes the --capabilities flag on the deploy command.

Closes #25 