### PR TITLE
Add kata-200 — Amazon Connect Basics: Instance, Hours of Operation & …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -533,10 +533,10 @@ The following katas are planned for the CloudKata library. All are open for comm
 
 | ID | Title | Level | Type | Services | Status |
 |---|---|---|---|---|---|
-| kata-200 | Amazon Connect Basics — Instance, Hours of Operation & Queues | 200 | Depth | Connect | Open |
+| [kata-200](./katas/kata-200-amazon-connect-basics/) | Amazon Connect Basics — Instance, Hours of Operation & Queues | 200 | Depth | Connect | Published |
 | [kata-201](./katas/kata-201-dynamodb-core/) | DynamoDB Core — Tables, Keys, Indexes & Capacity Modes | 200 | Depth | DynamoDB | Published |
 | [kata-202](./katas/kata-202-lexv2-advanced/) | Amazon Lex V2 Advanced — Versioning, Aliases & Lambda Fulfillment | 200 | Depth | Lex V2, Lambda | Published |
-| [kata-203](./katas/kata-203-api-gateway-lambda-rest/)   | API Gateway + Lambda — REST API & Proxy Integration | 200 | Breadth | API Gateway, Lambda | Open |
+| [kata-203](./katas/kata-203-api-gateway-lambda-rest/)   | API Gateway + Lambda — REST API & Proxy Integration | 200 | Breadth | API Gateway, Lambda | Published |
 | kata-204 | S3 + Lambda — Event Notifications & Triggers | 200 | Breadth | S3, Lambda | Open |
 | kata-205 | Lambda + SQS — Event Source Mapping & Error Handling | 200 | Breadth | Lambda, SQS | Open |
 | kata-206 | RDS Basics — Instances, Subnet Groups & Parameter Groups | 200 | Depth | RDS | Open |

--- a/katas/kata-200-amazon-connect-basics/HINTS.md
+++ b/katas/kata-200-amazon-connect-basics/HINTS.md
@@ -1,0 +1,341 @@
+# kata-200 Hints — Amazon Connect Basics: Instance, Hours of Operation & Queue
+
+> ⚠️ **Spoiler warning.** Each hint section reveals progressively more detail.
+> Try to solve each requirement on your own before opening a hint. The learning
+> is in the struggle.
+
+---
+
+## How to use these hints
+
+Hints are organized by requirement number matching the README. Each requirement
+has up to three levels:
+
+- **Hint 1** — a nudge in the right direction
+- **Hint 2** — more specific guidance
+- **Hint 3** — the exact approach (near-solution level)
+
+---
+
+## Requirement 1 — Connect Instance
+
+<details>
+<summary>Hint 1 — What an instance is and where to start</summary>
+
+An Amazon Connect instance is the top-level container for your contact center.
+Everything else — queues, hours of operation, contact flows, agents — lives
+inside an instance. Creating the instance is always the first step because no
+dependent resource can exist without one.
+
+Connect instances are created through the Amazon Connect console, the AWS CLI
+(`aws connect`), or CloudFormation (`AWS::Connect::Instance`). The console
+wizard asks several questions during setup; the key ones are the instance alias
+and how users will be managed.
+
+</details>
+
+<details>
+<summary>Hint 2 — Identity management and the instance alias</summary>
+
+When creating an instance, AWS asks how you want to manage users. There are
+three options: Connect's own built-in directory, an existing AWS Directory
+Service directory, or a SAML 2.0 identity provider. For this kata there is no
+external directory — use Connect's built-in option.
+
+The instance alias becomes part of the URL used to access the Connect admin
+interface and must be globally unique across all AWS accounts. It can contain
+letters, numbers, and hyphens, and must not start with `d-`.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact configuration</summary>
+
+- **Instance alias:** `kata-200-instance`
+- **Identity management type:** `CONNECT_MANAGED` (Connect's built-in user
+  directory — select "Store users in Amazon Connect" in the console)
+
+In the Amazon Connect console, choose **Add an instance**, select
+**Store users in Amazon Connect**, enter `kata-200-instance` as the alias,
+and step through the wizard accepting the defaults for the remaining pages
+(telephony, data storage, and so on). The instance will show a status of
+**Creating** for several minutes before becoming active.
+
+In CloudFormation, use `AWS::Connect::Instance` with:
+```yaml
+IdentityManagementType: CONNECT_MANAGED
+InstanceAlias: kata-200-instance
+Attributes:
+  InboundCalls: true
+  OutboundCalls: true
+```
+
+`Attributes` with at least `InboundCalls` and `OutboundCalls` is required by
+the CloudFormation schema even if you do not plan to use telephony.
+
+</details>
+
+---
+
+## Requirement 2 — Hours of Operation
+
+<details>
+<summary>Hint 1 — What hours of operation do</summary>
+
+An hours of operation resource defines when your contact center is open. It is
+a named schedule attached to your instance. Queues reference it to determine
+whether to accept or block incoming contacts. A queue cannot exist without an
+hours of operation — it is a required dependency, not an optional setting.
+
+Hours of operation live inside an instance, so you must have a working instance
+before you can create them.
+
+</details>
+
+<details>
+<summary>Hint 2 — Schedule structure and timezone</summary>
+
+A schedule is made up of individual day entries, each specifying a start time
+and end time. You need one entry per day you want the contact center to be open.
+Five entries are needed to cover Monday through Friday. Times are expressed in
+24-hour format using separate hours and minutes values.
+
+You also need to choose a timezone for the schedule. Connect uses IANA timezone
+names (for example, `America/New_York` or `Europe/London`). The timezone
+determines how the times are interpreted — if you want 09:00 to mean 9 AM
+Eastern, choose an Eastern timezone.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact configuration</summary>
+
+- **Name:** `kata-200-BasicHours`
+- **Instance:** `kata-200-instance`
+- **Timezone:** any valid IANA timezone (e.g. `America/New_York`)
+- **Schedule:** five entries, one per weekday, each with start `09:00` and end
+  `17:00` — expressed as `Hours: 9, Minutes: 0` and `Hours: 17, Minutes: 0`
+
+In the Amazon Connect admin console, go to **Routing** → **Hours of operation**
+→ **Add new set of hours**. Set the name, choose a timezone, then configure
+five rows for Monday through Friday with 9:00 AM to 5:00 PM.
+
+In CloudFormation, use `AWS::Connect::HoursOfOperation`:
+```yaml
+Name: kata-200-BasicHours
+InstanceArn: !GetAtt ConnectInstance.Arn
+TimeZone: America/New_York
+Config:
+  - Day: MONDAY
+    StartTime: { Hours: 9, Minutes: 0 }
+    EndTime:   { Hours: 17, Minutes: 0 }
+  - Day: TUESDAY
+    StartTime: { Hours: 9, Minutes: 0 }
+    EndTime:   { Hours: 17, Minutes: 0 }
+  - Day: WEDNESDAY
+    StartTime: { Hours: 9, Minutes: 0 }
+    EndTime:   { Hours: 17, Minutes: 0 }
+  - Day: THURSDAY
+    StartTime: { Hours: 9, Minutes: 0 }
+    EndTime:   { Hours: 17, Minutes: 0 }
+  - Day: FRIDAY
+    StartTime: { Hours: 9, Minutes: 0 }
+    EndTime:   { Hours: 17, Minutes: 0 }
+Tags:
+  - Key: Project
+    Value: CloudKata
+  - Key: Kata
+    Value: kata-200
+```
+
+</details>
+
+---
+
+## Requirement 3 — Queue
+
+<details>
+<summary>Hint 1 — What a queue is and what it needs</summary>
+
+A queue is where contacts wait until an agent is available to handle them.
+Every queue in Connect must be associated with an hours of operation — Connect
+uses this association to determine when the queue is open and eligible to
+receive contacts. The hours of operation must already exist before you create
+the queue.
+
+</details>
+
+<details>
+<summary>Hint 2 — Creating the queue and linking it to hours of operation</summary>
+
+In the Connect admin console, go to **Routing** → **Queues** → **Add new queue**.
+Give it a name and then choose the hours of operation from a dropdown. The
+dropdown lists all hours of operation in the current instance — you should see
+`kata-200-BasicHours` there once it has been created.
+
+Via the CLI, `aws connect create-queue` takes `--hours-of-operation-id`, which
+accepts either the ID or the ARN of the hours of operation.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact configuration</summary>
+
+- **Queue name:** `kata-200-BasicQueue`
+- **Instance:** `kata-200-instance`
+- **Hours of operation:** `kata-200-BasicHours`
+
+In CloudFormation, use `AWS::Connect::Queue`. The `HoursOfOperationArn`
+property requires the full ARN of the hours of operation — use `!GetAtt` to
+reference it from the hours of operation resource:
+
+```yaml
+Name: kata-200-BasicQueue
+InstanceArn: !GetAtt ConnectInstance.Arn
+HoursOfOperationArn: !GetAtt BasicHours.HoursOfOperationArn
+Tags:
+  - Key: Project
+    Value: CloudKata
+  - Key: Kata
+    Value: kata-200
+```
+
+Note that the property is called `HoursOfOperationArn` (requires the ARN),
+not `HoursOfOperationId`.
+
+</details>
+
+---
+
+## Requirement 4 — Tags
+
+<details>
+<summary>Hint 1 — Which resources need tags</summary>
+
+Tags are required on the hours of operation and the queue. The Connect instance
+itself does not need to be tagged for this kata — Connect instances have limited
+tagging support through CloudFormation, and the validator does not check instance
+tags.
+
+</details>
+
+<details>
+<summary>Hint 2 — Where to add tags in the console</summary>
+
+For **hours of operation**: open the hours of operation in the Connect admin
+console, scroll to the **Tags** section at the bottom of the page, and add the
+tags there.
+
+For the **queue**: open the queue in the Connect admin console under
+**Routing** → **Queues**, scroll to the **Tags** section, and add the tags.
+
+Alternatively, both resources can be tagged via the CLI using
+`aws connect tag-resource --resource-arn <arn> --tags Key=Project,Value=CloudKata Key=Kata,Value=kata-200`.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact tag values</summary>
+
+Tags are case-sensitive. The validator uses `aws connect list-tags-for-resource`
+and checks for these exact values on both the hours of operation and the queue:
+
+- Key: `Project` — Value: `CloudKata`
+- Key: `Kata` — Value: `kata-200`
+
+The Connect tagging API returns tags as a flat map `{"tags": {"Key": "Value"}}`.
+If tags appear in the console but the validator still fails, confirm the exact
+spelling and capitalisation match.
+
+</details>
+
+---
+
+## General Troubleshooting
+
+<details>
+<summary>Check 2 failing — instance stuck in CREATION_IN_PROGRESS</summary>
+
+Connect instances typically take 2–5 minutes to become ACTIVE after the API
+call returns. The validator polls for up to 5 minutes before marking this check
+as failed. If you are seeing this after waiting, check the Connect console for
+a `CREATION_FAILED` status — this usually means the instance alias is already
+in use by another account (aliases are globally unique). If creation failed,
+delete the instance and choose a different alias, then re-create.
+
+</details>
+
+<details>
+<summary>Check 4 failing — schedule does not match Monday-Friday 09:00-17:00</summary>
+
+The validator calls `describe-hours-of-operation` and checks that all five
+weekday entries (MONDAY through FRIDAY) have `StartTime.Hours == 9`,
+`StartTime.Minutes == 0`, `EndTime.Hours == 17`, and `EndTime.Minutes == 0`.
+Common causes of failure: configuring only some days (e.g. missing Friday),
+using 12-hour time incorrectly (entering `9` for 9 PM instead of `21`), or
+having non-zero minutes (e.g. `StartTime.Minutes: 1` instead of `0`). Check
+the `Config` array in `describe-hours-of-operation` output directly to debug.
+
+</details>
+
+<details>
+<summary>Check 6 failing — queue not associated with correct hours of operation</summary>
+
+The validator calls `describe-queue` and compares `.Queue.HoursOfOperationId`
+against the ID of `kata-200-BasicHours`. If you created the queue before the
+hours of operation existed, the queue may have been linked to the default
+hours of operation that Connect creates automatically. In the Connect admin
+console, open the queue under **Routing** → **Queues** and verify that the
+hours of operation field shows `kata-200-BasicHours`. If it shows something
+else, update the queue to reference the correct hours of operation.
+
+</details>
+
+<details>
+<summary>Check 7 or 8 failing — tags not found</summary>
+
+Connect uses its own tagging API (`list-tags-for-resource`) which returns a
+lowercase `tags` map. If you tagged the resources through CloudFormation or the
+console and the check still fails, verify the resource ARNs are correct — the
+ARN format for Connect resources is:
+`arn:aws:connect:{region}:{account}:instance/{instance-id}/operating-hours/{hours-id}`
+for hours of operation, and
+`arn:aws:connect:{region}:{account}:instance/{instance-id}/queue/{queue-id}`
+for queues. The validator pulls these ARNs from `list-hours-of-operations` and
+`list-queues` output, so if those resources were found by name, the ARN used
+for tag lookup should be correct.
+
+</details>
+
+<details>
+<summary>CloudFormation stack stuck in CREATE_IN_PROGRESS for the instance</summary>
+
+CloudFormation waits for the instance to reach ACTIVE before signalling success
+on the `AWS::Connect::Instance` resource. This typically takes 3–5 minutes.
+If the stack is still in `CREATE_IN_PROGRESS` after 10 minutes, check the
+CloudFormation events tab for errors. A common cause is hitting the 30-day
+instance creation limit — the event will show a service error message indicating
+the limit has been reached.
+
+</details>
+
+---
+
+## Still stuck?
+
+The complete working solution is in [solution.yml](./solution.yml).
+
+Deploy it with:
+
+```bash
+aws cloudformation deploy \
+  --template-file solution.yml \
+  --stack-name kata-200-solution
+```
+
+No `--capabilities` flag is required because the template does not create any
+IAM resources.
+
+Then re-run `validate.sh`. A correctly deployed solution should score 8/8.
+Study the solution to understand what you missed, then tear it down and try
+again from scratch.

--- a/katas/kata-200-amazon-connect-basics/README.md
+++ b/katas/kata-200-amazon-connect-basics/README.md
@@ -1,0 +1,209 @@
+---
+id: kata-200
+title: "Amazon Connect Basics — Instance, Hours of Operation & Queue"
+level: 200
+type: depth
+services:
+  - connect
+tags:
+  - connect
+  - contact-center
+  - depth
+  - foundational
+estimated_time: 45 minutes
+estimated_cost: "$0.00"
+author: Faisal Akhtar
+github: https://github.com/fakhtar
+---
+
+# kata-200 — Amazon Connect Basics: Instance, Hours of Operation & Queue
+
+## Overview
+
+In this kata you will provision the foundational building blocks of an Amazon
+Connect contact center. You will create a Connect instance, configure when the
+contact center is open, and set up a queue that uses those hours. These three
+resources form the prerequisite layer that every contact flow, routing profile,
+and agent configuration depends on.
+
+This kata introduces Connect-specific concepts: how instances are identified
+and scoped, why hours of operation must exist before a queue can be created,
+and how the two resources are linked.
+
+---
+
+## Prerequisites
+
+- An active AWS account
+- Access to AWS CloudShell
+- IAM permissions to create and manage Amazon Connect instances, hours of
+  operation, and queues
+
+> ⚠️ **Instance limit:** AWS enforces a limit on how many Connect instances
+> you can create and delete within a 30-day period. If you hit this limit, you
+> will need to wait before creating new instances. Plan your cleanup accordingly.
+
+---
+
+## Cost & Time
+
+| | |
+|---|---|
+| ⏱ Estimated Time | ~45 minutes |
+| 💰 Estimated Cost | $0.00 |
+
+> ⚠️ **Cost Warning:** These are estimates only. Amazon Connect charges are
+> based on usage (calls, tasks, and so on). The resources created in this kata
+> do not generate usage charges on their own. All charges are your
+> responsibility. Always run cleanup instructions when finished.
+
+---
+
+## Scenario
+
+You are provisioning the AWS infrastructure for a new contact center team.
+Before any agent can take a call or any contact flow can route traffic, the
+core scaffolding must exist: an instance to host everything, a schedule that
+defines when the center is open, and a queue where contacts will wait. Your
+job is to provision this foundation.
+
+---
+
+## Requirements
+
+Build the following infrastructure in your AWS account. All resource names
+must follow the naming convention: `kata-200-ResourceName`
+
+You are given a spec, not a tutorial. Use the AWS Console, CLI, IaC, or any
+tools you choose to meet these requirements. Consult the AWS documentation,
+use AI assistants, or search the web — whatever you would use on the job.
+
+---
+
+### Requirement 1 — Connect Instance
+
+Create an Amazon Connect instance with the instance alias `kata-200-instance`.
+The instance must be active before any dependent resources can be created.
+Use CONNECT_MANAGED identity management.
+
+---
+
+### Requirement 2 — Hours of Operation
+
+Create a hours of operation named `kata-200-BasicHours` within the instance.
+The schedule should represent standard business hours: Monday through Friday,
+09:00 to 17:00. Choose an appropriate timezone.
+
+---
+
+### Requirement 3 — Queue
+
+Create a queue named `kata-200-BasicQueue` within the instance. The queue
+must be associated with `kata-200-BasicHours`.
+
+---
+
+### Requirement 4 — Tags
+
+Tag the hours of operation and the queue with the standard CloudKata tags:
+
+- `Project: CloudKata`
+- `Kata: kata-200`
+
+> **Note:** Amazon Connect instances do not support tagging via the standard
+> CloudFormation `Tags` property. Instance tags are managed separately and
+> are not validated by this kata.
+
+---
+
+## Running the Validator
+
+Once you have built the required infrastructure, open AWS CloudShell and
+upload or copy `validate.sh` to your CloudShell environment, then run:
+
+```bash
+sed -i 's/\r//' validate.sh
+chmod +x validate.sh
+./validate.sh
+```
+
+> ⏳ **Allow time for the instance to become active.** A newly created Connect
+> instance can take several minutes to reach `ACTIVE` status. The validator
+> will wait and retry if the instance is still initialising.
+
+The validator checks your live AWS infrastructure and reports a score.
+A fully passing result looks like this:
+
+```
+==================================================
+ CloudKata Validator — kata-200
+ Amazon Connect Basics: Instance, Hours of Operation & Queue
+==================================================
+
+✅ PASS — Connect instance 'kata-200-instance' exists
+✅ PASS — Instance status is ACTIVE
+✅ PASS — Hours of operation 'kata-200-BasicHours' exists
+✅ PASS — Hours of operation covers Monday to Friday, 09:00-17:00
+✅ PASS — Queue 'kata-200-BasicQueue' exists
+✅ PASS — Queue is associated with 'kata-200-BasicHours'
+✅ PASS — Required tags are present on hours of operation
+✅ PASS — Required tags are present on queue
+
+==================================================
+ Results: 8/8 checks passed (100%)
+==================================================
+
+ 🎉 Perfect score! All kata-200 requirements met.
+```
+
+---
+
+## Cleanup
+
+Always clean up your resources when you are finished.
+
+> ⚠️ **Instance deletion counts against your 30-day limit.** AWS tracks
+> instance creations and deletions together. Deleting this instance will
+> count toward the limit just as creating it did.
+
+### Step 1 — Delete CloudFormation stacks (if applicable)
+
+If you deployed `solution.yml`, delete that stack first via CloudFormation.
+
+```bash
+aws cloudformation delete-stack --stack-name kata-200-solution
+aws cloudformation wait stack-delete-complete --stack-name kata-200-solution
+```
+
+### Step 2 — Manual Cleanup
+
+If you created resources manually:
+
+```bash
+# Get the instance ID
+INSTANCE_ID=$(aws connect list-instances \
+  --query "InstanceSummaryList[?InstanceAlias=='kata-200-instance'].Id" \
+  --output text)
+
+# Delete the instance (queues and hours of operation are deleted automatically)
+aws connect delete-instance --instance-id "$INSTANCE_ID"
+```
+
+> Queues and hours of operation cannot be deleted independently — they are
+> removed when the instance is deleted.
+
+### Step 3 — Verify in the console
+
+Confirm that `kata-200-instance` no longer appears in the Amazon Connect
+console under **Instances**.
+
+---
+
+## Hints & Solution
+
+Stuck? Refer to [HINTS.md](./HINTS.md) for progressive hints without full
+spoilers.
+
+The complete solution is available in [solution.yml](./solution.yml).
+Deploying `solution.yml` and re-running `validate.sh` should produce a
+score of 100%.

--- a/katas/kata-200-amazon-connect-basics/solution.yml
+++ b/katas/kata-200-amazon-connect-basics/solution.yml
@@ -1,0 +1,136 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  CloudKata kata-200 - Amazon Connect Basics: Instance, Hours of Operation & Queue.
+  Deploys a Connect instance with alias kata-200-instance, hours of operation
+  kata-200-BasicHours covering Monday-Friday 09:00-17:00 UTC, and queue
+  kata-200-BasicQueue associated with those hours.
+
+# ==============================================================================
+# Resources
+# ==============================================================================
+Resources:
+
+  # ----------------------------------------------------------------------------
+  # Connect Instance — kata-200-instance
+  #
+  # IdentityManagementType: CONNECT_MANAGED uses Connect's built-in user
+  # directory. This is the simplest option and requires no external directory.
+  #
+  # Attributes.InboundCalls and OutboundCalls are required properties even
+  # when not strictly needed for this kata. Both are enabled here.
+  #
+  # Note: AWS::Connect::Instance does not support the standard CloudFormation
+  # Tags property. Instance tags must be applied separately via the CLI or
+  # console after creation. The validator does not check instance tags.
+  # ----------------------------------------------------------------------------
+  ConnectInstance:
+    Type: AWS::Connect::Instance
+    Properties:
+      IdentityManagementType: CONNECT_MANAGED
+      InstanceAlias: kata-200-instance
+      Attributes:
+        InboundCalls: true
+        OutboundCalls: true
+
+  # ----------------------------------------------------------------------------
+  # Hours of Operation — kata-200-BasicHours
+  #
+  # Standard business hours: Monday through Friday, 09:00-17:00.
+  # TimeZone: America/New_York (EST/EDT) — a common, unambiguous named timezone.
+  #
+  # Config requires one entry per day. Five entries cover the full weekday
+  # schedule. StartTime and EndTime use Hours (0-23) and Minutes (0-59).
+  #
+  # InstanceArn: !GetAtt ConnectInstance.Arn — the instance ARN is available
+  # as a GetAtt return value on AWS::Connect::Instance.
+  # ----------------------------------------------------------------------------
+  BasicHours:
+    Type: AWS::Connect::HoursOfOperation
+    Properties:
+      Name: kata-200-BasicHours
+      Description: "Standard business hours - Monday to Friday 09:00-17:00"
+      InstanceArn: !GetAtt ConnectInstance.Arn
+      TimeZone: America/New_York
+      Config:
+        - Day: MONDAY
+          StartTime:
+            Hours: 9
+            Minutes: 0
+          EndTime:
+            Hours: 17
+            Minutes: 0
+        - Day: TUESDAY
+          StartTime:
+            Hours: 9
+            Minutes: 0
+          EndTime:
+            Hours: 17
+            Minutes: 0
+        - Day: WEDNESDAY
+          StartTime:
+            Hours: 9
+            Minutes: 0
+          EndTime:
+            Hours: 17
+            Minutes: 0
+        - Day: THURSDAY
+          StartTime:
+            Hours: 9
+            Minutes: 0
+          EndTime:
+            Hours: 17
+            Minutes: 0
+        - Day: FRIDAY
+          StartTime:
+            Hours: 9
+            Minutes: 0
+          EndTime:
+            Hours: 17
+            Minutes: 0
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-200
+
+  # ----------------------------------------------------------------------------
+  # Queue — kata-200-BasicQueue
+  #
+  # HoursOfOperationArn: the queue resource requires the full ARN of the hours
+  # of operation, not its ID. GetAtt on HoursOfOperationArn returns the ARN.
+  #
+  # No MaxContacts or OutboundCallerConfig are set — both are optional and
+  # not required by this kata.
+  # ----------------------------------------------------------------------------
+  BasicQueue:
+    Type: AWS::Connect::Queue
+    Properties:
+      Name: kata-200-BasicQueue
+      Description: "kata-200 basic queue associated with business hours"
+      InstanceArn: !GetAtt ConnectInstance.Arn
+      HoursOfOperationArn: !GetAtt BasicHours.HoursOfOperationArn
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-200
+
+# ==============================================================================
+# Outputs
+# ==============================================================================
+Outputs:
+  InstanceArn:
+    Description: ARN of the Connect instance
+    Value: !GetAtt ConnectInstance.Arn
+
+  InstanceId:
+    Description: ID of the Connect instance
+    Value: !Ref ConnectInstance
+
+  HoursOfOperationArn:
+    Description: ARN of the hours of operation
+    Value: !GetAtt BasicHours.HoursOfOperationArn
+
+  QueueArn:
+    Description: ARN of the queue
+    Value: !GetAtt BasicQueue.QueueArn

--- a/katas/kata-200-amazon-connect-basics/validate.sh
+++ b/katas/kata-200-amazon-connect-basics/validate.sh
@@ -1,0 +1,263 @@
+#!/bin/bash
+
+# ==============================================================================
+# CloudKata Validator — kata-200
+# Amazon Connect Basics: Instance, Hours of Operation & Queue
+# ==============================================================================
+
+INSTANCE_ALIAS="kata-200-instance"
+HOURS_NAME="kata-200-BasicHours"
+QUEUE_NAME="kata-200-BasicQueue"
+TOTAL_CHECKS=8
+
+PASS=0
+FAIL=0
+
+pass() { echo "✅ PASS — $1"; ((PASS++)); }
+fail() { echo "❌ FAIL — $1"; ((FAIL++)); }
+
+echo ""
+echo "=================================================="
+echo " CloudKata Validator — kata-200"
+echo " Amazon Connect Basics: Instance, Hours of Operation & Queue"
+echo "=================================================="
+echo ""
+
+# ------------------------------------------------------------------------------
+# Check 1 — Connect instance exists (hard gate)
+# ------------------------------------------------------------------------------
+echo "Checking Connect instance..."
+INSTANCE_JSON=$(aws connect list-instances \
+  --output json 2>/dev/null | \
+  jq --arg alias "$INSTANCE_ALIAS" \
+  '.InstanceSummaryList[] | select(.InstanceAlias == $alias)' 2>/dev/null)
+
+if [ -z "$INSTANCE_JSON" ]; then
+  echo "❌ FAIL — Connect instance '$INSTANCE_ALIAS' not found. Cannot continue."
+  echo ""
+  echo "=================================================="
+  echo " Results: 0/$TOTAL_CHECKS checks passed (0%)"
+  echo "=================================================="
+  exit 1
+fi
+pass "Connect instance '$INSTANCE_ALIAS' exists"
+
+INSTANCE_ID=$(echo "$INSTANCE_JSON" | jq -r '.Id')
+INSTANCE_STATUS=$(echo "$INSTANCE_JSON" | jq -r '.InstanceStatus')
+
+# ------------------------------------------------------------------------------
+# Check 2 — Instance status is ACTIVE
+#
+# Connect instances can take several minutes to become ACTIVE after creation.
+# Poll up to 10 times (5 minutes) before failing.
+# ------------------------------------------------------------------------------
+echo "Checking instance status..."
+if [ "$INSTANCE_STATUS" = "ACTIVE" ]; then
+  pass "Instance status is ACTIVE"
+else
+  echo "  Instance status is '$INSTANCE_STATUS' — waiting for ACTIVE (up to 5 minutes)..."
+  ATTEMPTS=0
+  MAX_ATTEMPTS=10
+  while [ "$INSTANCE_STATUS" != "ACTIVE" ] && [ "$ATTEMPTS" -lt "$MAX_ATTEMPTS" ]; do
+    sleep 30
+    ((ATTEMPTS++))
+    INSTANCE_JSON=$(aws connect list-instances \
+      --output json 2>/dev/null | \
+      jq --arg alias "$INSTANCE_ALIAS" \
+      '.InstanceSummaryList[] | select(.InstanceAlias == $alias)' 2>/dev/null)
+    INSTANCE_STATUS=$(echo "$INSTANCE_JSON" | jq -r '.InstanceStatus')
+    echo "  Attempt $ATTEMPTS/$MAX_ATTEMPTS — status: $INSTANCE_STATUS"
+  done
+
+  if [ "$INSTANCE_STATUS" = "ACTIVE" ]; then
+    pass "Instance status is ACTIVE"
+  else
+    fail "Instance status is '$INSTANCE_STATUS' — expected ACTIVE"
+    fail "Hours of operation '$HOURS_NAME' could not be checked — instance not ACTIVE"
+    fail "Hours of operation schedule could not be checked — instance not ACTIVE"
+    fail "Queue '$QUEUE_NAME' could not be checked — instance not ACTIVE"
+    fail "Queue association could not be checked — instance not ACTIVE"
+    fail "Required tags could not be checked on hours of operation — instance not ACTIVE"
+    fail "Required tags could not be checked on queue — instance not ACTIVE"
+    PCT=$(( (PASS * 100) / TOTAL_CHECKS ))
+    echo ""
+    echo "=================================================="
+    echo " Results: $PASS/$TOTAL_CHECKS checks passed ($PCT%)"
+    echo "=================================================="
+    echo " 📖 Keep going — consult HINTS.md for guidance."
+    echo ""
+    exit 1
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 3 — Hours of operation exists
+# ------------------------------------------------------------------------------
+echo "Checking hours of operation..."
+HOURS_LIST=$(aws connect list-hours-of-operations \
+  --instance-id "$INSTANCE_ID" \
+  --output json 2>/dev/null)
+
+HOURS_JSON=$(echo "$HOURS_LIST" | \
+  jq --arg name "$HOURS_NAME" \
+  '.HoursOfOperationSummaryList[] | select(.Name == $name)' 2>/dev/null)
+
+if [ -z "$HOURS_JSON" ]; then
+  fail "Hours of operation '$HOURS_NAME' not found in instance '$INSTANCE_ALIAS'"
+  HOURS_ID=""
+  HOURS_ARN=""
+else
+  pass "Hours of operation '$HOURS_NAME' exists"
+  HOURS_ID=$(echo "$HOURS_JSON" | jq -r '.Id')
+  HOURS_ARN=$(echo "$HOURS_JSON" | jq -r '.Arn')
+fi
+
+# ------------------------------------------------------------------------------
+# Check 4 — Hours of operation covers Monday-Friday 09:00-17:00
+# ------------------------------------------------------------------------------
+echo "Checking hours of operation schedule..."
+if [ -z "$HOURS_ID" ]; then
+  fail "Hours of operation schedule could not be checked — hours of operation not found"
+else
+  HOURS_DETAIL=$(aws connect describe-hours-of-operation \
+    --instance-id "$INSTANCE_ID" \
+    --hours-of-operation-id "$HOURS_ID" \
+    --output json 2>/dev/null)
+
+  # Count Config entries that are weekdays (MON-FRI) with 09:00-17:00
+  MATCHING_DAYS=$(echo "$HOURS_DETAIL" | jq '
+    [.HoursOfOperation.Config[] |
+      select(
+        (.Day == "MONDAY" or .Day == "TUESDAY" or .Day == "WEDNESDAY" or
+         .Day == "THURSDAY" or .Day == "FRIDAY") and
+        .StartTime.Hours == 9 and .StartTime.Minutes == 0 and
+        .EndTime.Hours == 17 and .EndTime.Minutes == 0
+      )
+    ] | length' 2>/dev/null)
+
+  # All five weekdays must be present with correct times
+  WEEKDAY_COUNT=$(echo "$HOURS_DETAIL" | jq '
+    [.HoursOfOperation.Config[] |
+      select(.Day == "MONDAY" or .Day == "TUESDAY" or .Day == "WEDNESDAY" or
+             .Day == "THURSDAY" or .Day == "FRIDAY")
+    ] | length' 2>/dev/null)
+
+  if [ "$MATCHING_DAYS" -eq 5 ] && [ "$WEEKDAY_COUNT" -eq 5 ]; then
+    pass "Hours of operation covers Monday to Friday, 09:00-17:00"
+  else
+    fail "Hours of operation schedule does not match Monday-Friday 09:00-17:00 — found $MATCHING_DAYS/5 matching weekday entries"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 5 — Queue exists
+# ------------------------------------------------------------------------------
+echo "Checking queue..."
+QUEUE_LIST=$(aws connect list-queues \
+  --instance-id "$INSTANCE_ID" \
+  --queue-types STANDARD \
+  --output json 2>/dev/null)
+
+QUEUE_JSON=$(echo "$QUEUE_LIST" | \
+  jq --arg name "$QUEUE_NAME" \
+  '.QueueSummaryList[] | select(.Name == $name)' 2>/dev/null)
+
+if [ -z "$QUEUE_JSON" ]; then
+  fail "Queue '$QUEUE_NAME' not found in instance '$INSTANCE_ALIAS'"
+  QUEUE_ID=""
+  QUEUE_ARN=""
+else
+  pass "Queue '$QUEUE_NAME' exists"
+  QUEUE_ID=$(echo "$QUEUE_JSON" | jq -r '.Id')
+  QUEUE_ARN=$(echo "$QUEUE_JSON" | jq -r '.Arn')
+fi
+
+# ------------------------------------------------------------------------------
+# Check 6 — Queue is associated with kata-200-BasicHours
+# ------------------------------------------------------------------------------
+echo "Checking queue association..."
+if [ -z "$QUEUE_ID" ]; then
+  fail "Queue association could not be checked — queue not found"
+elif [ -z "$HOURS_ID" ]; then
+  fail "Queue association could not be checked — hours of operation not found"
+else
+  QUEUE_DETAIL=$(aws connect describe-queue \
+    --instance-id "$INSTANCE_ID" \
+    --queue-id "$QUEUE_ID" \
+    --output json 2>/dev/null)
+
+  QUEUE_HOURS_ID=$(echo "$QUEUE_DETAIL" | jq -r '.Queue.HoursOfOperationId // empty' 2>/dev/null)
+
+  if [ "$QUEUE_HOURS_ID" = "$HOURS_ID" ]; then
+    pass "Queue is associated with '$HOURS_NAME'"
+  else
+    fail "Queue is not associated with '$HOURS_NAME' — check the hours of operation linked to the queue"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 7 — Required tags on hours of operation
+# ------------------------------------------------------------------------------
+echo "Checking hours of operation tags..."
+if [ -z "$HOURS_ARN" ]; then
+  fail "Required tags could not be checked on hours of operation — hours of operation not found"
+else
+  HOURS_TAGS=$(aws connect list-tags-for-resource \
+    --resource-arn "$HOURS_ARN" \
+    --output json 2>/dev/null)
+
+  HOURS_PROJECT=$(echo "$HOURS_TAGS" | jq -r '.tags.Project // empty' 2>/dev/null)
+  HOURS_KATA=$(echo "$HOURS_TAGS" | jq -r '.tags.Kata // empty' 2>/dev/null)
+
+  if [ "$HOURS_PROJECT" = "CloudKata" ] && [ "$HOURS_KATA" = "kata-200" ]; then
+    pass "Required tags are present on hours of operation"
+  else
+    MISSING=""
+    [ "$HOURS_PROJECT" != "CloudKata" ] && MISSING="Project: CloudKata "
+    [ "$HOURS_KATA" != "kata-200" ] && MISSING="${MISSING}Kata: kata-200"
+    fail "Missing or incorrect tags on hours of operation: $MISSING"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 8 — Required tags on queue
+# ------------------------------------------------------------------------------
+echo "Checking queue tags..."
+if [ -z "$QUEUE_ARN" ]; then
+  fail "Required tags could not be checked on queue — queue not found"
+else
+  QUEUE_TAGS=$(aws connect list-tags-for-resource \
+    --resource-arn "$QUEUE_ARN" \
+    --output json 2>/dev/null)
+
+  QUEUE_PROJECT=$(echo "$QUEUE_TAGS" | jq -r '.tags.Project // empty' 2>/dev/null)
+  QUEUE_KATA=$(echo "$QUEUE_TAGS" | jq -r '.tags.Kata // empty' 2>/dev/null)
+
+  if [ "$QUEUE_PROJECT" = "CloudKata" ] && [ "$QUEUE_KATA" = "kata-200" ]; then
+    pass "Required tags are present on queue"
+  else
+    MISSING=""
+    [ "$QUEUE_PROJECT" != "CloudKata" ] && MISSING="Project: CloudKata "
+    [ "$QUEUE_KATA" != "kata-200" ] && MISSING="${MISSING}Kata: kata-200"
+    fail "Missing or incorrect tags on queue: $MISSING"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Results
+# ------------------------------------------------------------------------------
+PCT=$(( (PASS * 100) / TOTAL_CHECKS ))
+
+echo ""
+echo "=================================================="
+echo " Results: $PASS/$TOTAL_CHECKS checks passed ($PCT%)"
+echo "=================================================="
+
+if [ "$PASS" -eq "$TOTAL_CHECKS" ]; then
+  echo " 🎉 Perfect score! All kata-200 requirements met."
+elif [ "$PASS" -ge 5 ]; then
+  echo " 🔧 Almost there — review the failed checks above."
+else
+  echo " 📖 Keep going — consult HINTS.md for guidance."
+fi
+echo ""


### PR DESCRIPTION
…Queue

Introduces kata-200, a depth-level 200 kata covering the foundational building blocks of an Amazon Connect contact center. Learners provision a Connect instance, configure a hours of operation schedule, and create a queue linked to that schedule. This is the first kata in the library covering the Connect service and establishes the resource dependency chain that all subsequent Connect katas will build on.

---

Requirements are written at spec level only. Key decisions:

- Requirement 1 names `CONNECT_MANAGED` identity management explicitly — this is the one case where naming the implementation detail is justified, because the other two options (EXISTING_DIRECTORY, SAML) require external infrastructure that cannot exist in a fresh account. Without this steer, learners would hit a confusing decision with no clear default.
- Requirement 2 describes the schedule as "standard business hours: Monday through Friday, 09:00 to 17:00" and says "choose an appropriate timezone" — the specific timezone is not validated, only the times and days are.
- Requirement 3 states association with `kata-200-BasicHours` as the observable outcome without naming the mechanism (HoursOfOperationArn vs HoursOfOperationId).
- A prominent note in Requirement 4 explains that Connect instance tagging is not supported via the standard CloudFormation Tags property and is not validated — preventing learners from chasing a non-existent check.
- Two callout blocks document the 30-day instance creation/deletion limit prominently in both the prerequisites and the cleanup sections, since hitting this limit silently blocks all subsequent kata work.
- The validator output block shows all 8 check names so learners know what is being measured before they start.

---

8 checks across two hard gates and six dependency-gated checks.

Check structure:
  1. Connect instance exists by alias (hard gate — exits on failure)
  2. Instance status is ACTIVE — polls up to 10 times at 30s intervals (5 minutes total) before failing and stubbing remaining 6 checks
  3. Hours of operation 'kata-200-BasicHours' exists in instance
  4. Schedule covers all five weekdays (MON-FRI) with 09:00-17:00 exactly
  5. Queue 'kata-200-BasicQueue' exists (STANDARD type only)
  6. Queue's HoursOfOperationId matches the ID of kata-200-BasicHours
  7. Required tags present on hours of operation
  8. Required tags present on queue

Key implementation notes:

Instance lookup: list-instances has no --filters flag — client-side jq select(.InstanceAlias == $alias) is the only option. The full InstanceSummaryList is fetched and filtered locally.

Status polling: the instance status check reads the already-fetched InstanceStatus field first; only if non-ACTIVE does it enter the polling loop. This avoids a 30s sleep on the common case where the instance is already ACTIVE (e.g. when re-running the validator after initial setup).

Schedule check uses two independent jq counts against describe-hours-of-operation output:
  - MATCHING_DAYS: entries where Day is MON-FRI AND times are exactly 09:00-17:00. Must equal 5.
  - WEEKDAY_COUNT: entries where Day is MON-FRI regardless of times. Must also equal 5. Both must be 5 to pass — this catches partial schedules (e.g. only 3 days) and correctly-timed-but-incomplete schedules independently. The error message reports MATCHING_DAYS/5 to help learners debug.

Queue filtered with --queue-types STANDARD to exclude agent queues, which Connect creates automatically and could produce a false name match if a learner happened to name an agent queue with the same prefix.

Queue association check compares describe-queue response field .Queue.HoursOfOperationId (an ID string) against the ID extracted from list-hours-of-operations. The describe-queue response does not return an ARN for the hours of operation, only the ID — using ARN comparison here would always fail.

Tags use aws connect list-tags-for-resource returning {"tags": {...}} — lowercase flat map, same pattern as API Gateway. Both hours of operation and queue ARNs are extracted from the list- responses rather than constructed manually, so they are always correct regardless of region or account.

bash -n syntax check passes clean.

---

3 resources in a clean dependency chain. No --capabilities flag required (no IAM resources).

Resources:
  - AWS::Connect::Instance (kata-200-instance) IdentityManagementType: CONNECT_MANAGED. Attributes block with InboundCalls: true and OutboundCalls: true is required by the CFN schema even though telephony is not exercised in this kata — omitting it causes a schema validation error at deploy time. No Tags property — AWS::Connect::Instance does not support the standard CloudFormation Tags property; the validator does not check instance tags.

  - AWS::Connect::HoursOfOperation (kata-200-BasicHours) InstanceArn: !GetAtt ConnectInstance.Arn. Five Config entries, one per weekday, each with StartTime {Hours: 9, Minutes: 0} and EndTime {Hours: 17, Minutes: 0}. TimeZone: America/New_York — a valid IANA timezone; any valid timezone would pass the validator since only the times and days are checked. Tags in list format [{Key, Value}]. GetAtt HoursOfOperationArn returns the full ARN for use by the queue resource.

  - AWS::Connect::Queue (kata-200-BasicQueue) HoursOfOperationArn: !GetAtt BasicHours.HoursOfOperationArn — the CFN property requires the ARN, not the ID. This is distinct from the CLI create-queue command which accepts --hours-of-operation-id (an ID). Using !Ref BasicHours would also work (Ref on AWS::Connect::HoursOfOperation returns the ARN), but GetAtt is explicit and unambiguous. Tags in list format [{Key, Value}].

CloudFormation waits for the Connect instance to reach ACTIVE before proceeding to dependent resources. Stack creation typically takes 3-5 minutes due to this wait.

---

Three-level progressive hints for all four requirements. All implementation specifics (CONNECT_MANAGED, IANA timezone format, HoursOfOperationArn vs HoursOfOperationId, Attributes block requirement) appear only at Hint 3.

Notable hint design decisions:
- Req 1 Hint 3 includes the Attributes block gotcha with explanation — this is the single most likely CloudFormation failure point, as the schema error message does not make it obvious what is missing.
- Req 2 Hint 2 explains IANA timezone naming conceptually before giving an example at Hint 3, because learners unfamiliar with Connect commonly try abbreviated forms like EST or UTC-5 which fail validation.
- Req 3 Hint 3 explicitly contrasts HoursOfOperationArn (CFN property, requires ARN) with HoursOfOperationId (CLI flag, takes ID) — this mismatch is the most common source of confusion when learners switch between console/CLI and CloudFormation paths.
- Req 4 Hint 2 includes the CLI tag-resource command as an alternative to the console, since some learners will prefer to tag via CLI after creating resources manually.

Troubleshooting sections cover five failure modes tied to specific validator check numbers: instance stuck in CREATION_IN_PROGRESS or CREATION_FAILED (check 2), schedule misconfiguration including partial days and non-zero minutes (check 4), queue linked to wrong hours of operation including Connect's auto-created default (check 6), tag lookup failures with ARN format explanation (checks 7/8), and CloudFormation stack stuck waiting on instance creation including the 30-day limit error (stack-level).

Closes #36 