### PR TITLE
Add kata-109 — SSM Parameter Store: Parameters, Types & Versioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -525,7 +525,7 @@ The following katas are planned for the CloudKata library. All are open for comm
 | [kata-106](./katas/kata-106-cloudwatch-basics/) | CloudWatch Basics — Billing Alarm & Alerting | 100 | Depth | CloudWatch | Published |
 | [kata-107](./katas/kata-107-sqs-basics/) | SQS Basics — Queues, Visibility & Dead-Letter Queues | 100 | Depth | SQS | Published |
 | [kata-108](./katas/kata-108-ec2-basics/)  | EC2 Basics — Instances, Security Groups & Key Pairs | 100 | Depth | EC2 | Published |
-| kata-109 | SSM Parameter Store — Parameters, Types & Versioning | 100 | Depth | SSM | Assigned |
+| [kata-109](./katas/kata-109-ssm-parameter-store/)| SSM Parameter Store — Parameters, Types & Versioning | 100 | Depth | SSM | Assigned |
 | [kata-110](./katas/kata-110-eventbridge-basics/) | EventBridge Basics — Rules, Targets & Scheduling | 100 | Depth | EventBridge | Published |
 | kata-111 | Secrets Manager Basics — Secrets & Access | 100 | Depth | Secrets Manager | In-Progress |
 

--- a/katas/kata-109-ssm-parameter-store/HINTS.md
+++ b/katas/kata-109-ssm-parameter-store/HINTS.md
@@ -1,0 +1,354 @@
+# kata-109 Hints — SSM Parameter Store: Parameters, Types & Versioning
+
+> ⚠️ **Spoiler warning.** Each hint section reveals progressively more detail.
+> Try to solve each requirement on your own before opening a hint. The learning
+> is in the struggle.
+
+---
+
+## How to use these hints
+
+Hints are organized by requirement number matching the README. Each requirement
+has up to three levels:
+
+- **Hint 1** — a nudge in the right direction
+- **Hint 2** — more specific guidance
+- **Hint 3** — the exact approach (near-solution level)
+
+---
+
+## Requirement 1 — String Parameter
+
+<details>
+<summary>Hint 1 — Where to start</summary>
+
+Parameter Store lives inside AWS Systems Manager (SSM). In the console,
+navigate to **Systems Manager** → **Parameter Store** → **Create parameter**.
+Parameters are identified by their name, which can use a hierarchical path
+format with forward slashes — for example `/myapp/config/setting`. This keeps
+parameters organised and makes it easy to apply IAM policies to a whole path.
+
+</details>
+
+<details>
+<summary>Hint 2 — Parameter types</summary>
+
+Parameter Store supports three types: `String` (plain text), `StringList`
+(comma-separated plain text), and `SecureString` (encrypted). A plaintext
+environment label like `dev` or `staging` does not need encryption — use the
+`String` type. The value is stored and returned exactly as you enter it.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact configuration</summary>
+
+- **Name:** `/kata-109/config/environment`
+- **Type:** `String`
+- **Value:** `dev`
+
+Create the parameter with value `dev` first. You will update it to `staging`
+in Requirement 3 — this is what drives the version counter. If you create it
+with `staging` directly, you will need to make a second update to reach
+version 2.
+
+In the console: **Systems Manager** → **Parameter Store** → **Create parameter**.
+Enter the name with the leading slash, select **String**, and enter `dev` as
+the value.
+
+Via CLI:
+```bash
+aws ssm put-parameter \
+  --name /kata-109/config/environment \
+  --type String \
+  --value dev
+```
+
+In CloudFormation, use `AWS::SSM::Parameter` with `Type: String`.
+
+</details>
+
+---
+
+## Requirement 2 — SecureString Parameter
+
+<details>
+<summary>Hint 1 — What SecureString means</summary>
+
+A `SecureString` parameter is encrypted at rest using AWS KMS. When you
+retrieve it, you get back the encrypted value unless you explicitly request
+decryption. This type is appropriate for sensitive values like API keys,
+passwords, and tokens that should not be stored in plain text. The encryption
+and decryption are handled transparently by SSM — you do not need to call KMS
+directly.
+
+</details>
+
+<details>
+<summary>Hint 2 — KMS key selection</summary>
+
+When creating a SecureString parameter, you must choose a KMS key for
+encryption. You can use the AWS-managed key for SSM (`aws/ssm`) which exists
+in every account and incurs no additional KMS charges for standard-tier
+parameters. You do not need to create a customer-managed key for this kata.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact configuration and CloudFormation limitation</summary>
+
+- **Name:** `/kata-109/config/api-key`
+- **Type:** `SecureString`
+- **Value:** `supersecret`
+- **KMS key:** use the default AWS-managed key (`aws/ssm`)
+
+In the console: **Systems Manager** → **Parameter Store** → **Create parameter**.
+Enter the name, select **SecureString**, leave the KMS key as the default
+`aws/ssm` key, and enter `supersecret` as the value.
+
+Via CLI:
+```bash
+aws ssm put-parameter \
+  --name /kata-109/config/api-key \
+  --type SecureString \
+  --value supersecret
+```
+
+> ⚠️ **CloudFormation limitation:** `AWS::SSM::Parameter` does not support
+> `Type: SecureString`. If you are using CloudFormation, you must create the
+> SecureString parameter via a custom resource backed by a Lambda function
+> that calls `ssm:PutParameter` with `Type=SecureString`. See `solution.yml`
+> for the full pattern.
+
+</details>
+
+---
+
+## Requirement 3 — Versioning
+
+<details>
+<summary>Hint 1 — How versioning works in Parameter Store</summary>
+
+Every time you update a parameter's value, Parameter Store automatically
+increments its version number. The first time you create a parameter it is
+version 1. Each subsequent update creates a new version. You can retrieve a
+specific historical version by appending `:version` to the parameter name —
+for example `/kata-109/config/environment:1` — but the default always returns
+the latest version. You cannot manually set the version number.
+
+</details>
+
+<details>
+<summary>Hint 2 — What "update" means</summary>
+
+Updating a parameter means calling `PutParameter` again with the same name
+and a new value, with the overwrite flag set. In the console, open the
+parameter and choose **Edit**, change the value, and save. Each save
+increments the version by one. The validator checks both that the current
+value is `staging` and that the version is 2 or higher — so the parameter
+must have been updated at least once after its initial creation.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact steps</summary>
+
+If you created the parameter with value `dev` in Requirement 1, update it now:
+
+In the console: open `/kata-109/config/environment`, choose **Edit**,
+change the value to `staging`, and save. The version shown in the console
+will increment to 2.
+
+Via CLI:
+```bash
+aws ssm put-parameter \
+  --name /kata-109/config/environment \
+  --value staging \
+  --overwrite
+```
+
+You can verify the version with:
+```bash
+aws ssm get-parameter \
+  --name /kata-109/config/environment \
+  --query 'Parameter.{Value:Value,Version:Version}'
+```
+
+</details>
+
+---
+
+## Requirement 4 — Tags
+
+<details>
+<summary>Hint 1 — Which parameter needs tags</summary>
+
+Only the `/kata-109/config/environment` String parameter requires tags. The
+SecureString parameter is excluded from tag validation in this kata due to API
+constraints with SecureString tagging.
+
+</details>
+
+<details>
+<summary>Hint 2 — How to tag SSM parameters</summary>
+
+SSM parameters are tagged differently from most AWS resources. Rather than
+using the standard `aws resourcegroupstaggingapi tag-resources` command, SSM
+has its own tagging API: `ssm add-tags-to-resource`. You must specify the
+resource type as `Parameter` and use the parameter name (not ARN) as the
+resource ID.
+
+In the console, open the parameter, choose the **Tags** tab, and add the
+key-value pairs there.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact tag values and CLI command</summary>
+
+Tags are case-sensitive. The validator checks for these exact values on
+`/kata-109/config/environment`:
+
+- Key: `Project` — Value: `CloudKata`
+- Key: `Kata` — Value: `kata-109`
+
+Via CLI:
+```bash
+aws ssm add-tags-to-resource \
+  --resource-type Parameter \
+  --resource-id /kata-109/config/environment \
+  --tags Key=Project,Value=CloudKata Key=Kata,Value=kata-109
+```
+
+In CloudFormation, `AWS::SSM::Parameter` supports tags as a flat map — not
+a list of `{Key, Value}` objects:
+
+```yaml
+Tags:
+  Project: CloudKata
+  Kata: kata-109
+```
+
+</details>
+
+---
+
+## General Troubleshooting
+
+<details>
+<summary>Check 3 failing — value is not 'staging'</summary>
+
+The validator reads the current value of `/kata-109/config/environment` and
+compares it to `staging`. If the value is still `dev`, you have not yet
+updated the parameter. If the value is something else, you may have edited
+it incorrectly. Use the CLI to check the current state:
+
+```bash
+aws ssm get-parameter \
+  --name /kata-109/config/environment \
+  --query 'Parameter.{Value:Value,Version:Version}'
+```
+
+</details>
+
+<details>
+<summary>Check 4 failing — version is less than 2</summary>
+
+If the version is 1, the parameter was created directly with `staging` and
+has never been updated. Create a second update to push the version to 2:
+
+```bash
+aws ssm put-parameter \
+  --name /kata-109/config/environment \
+  --value staging \
+  --overwrite
+```
+
+This writes the same value again — the version still increments even if the
+value does not change.
+
+</details>
+
+<details>
+<summary>Check 6 failing — parameter type is not SecureString</summary>
+
+The validator checks `.Parameter.Type` from `get-parameter`. If type is
+`String` instead of `SecureString`, the parameter was created with the wrong
+type. Parameter types cannot be changed after creation — you must delete
+the parameter and recreate it with `Type: SecureString`.
+
+```bash
+aws ssm delete-parameter --name /kata-109/config/api-key
+aws ssm put-parameter \
+  --name /kata-109/config/api-key \
+  --type SecureString \
+  --value supersecret
+```
+
+</details>
+
+<details>
+<summary>Check 7 failing — SecureString value is incorrect</summary>
+
+The validator retrieves the SecureString value using `--with-decryption`. If
+the value is returned as a ciphertext blob rather than `supersecret`, the
+CloudShell IAM role may not have `kms:Decrypt` permission for the `aws/ssm`
+key. Try retrieving the value manually to confirm:
+
+```bash
+aws ssm get-parameter \
+  --name /kata-109/config/api-key \
+  --with-decryption \
+  --query 'Parameter.Value'
+```
+
+If decryption fails, check that your IAM permissions include `kms:Decrypt`
+on the `aws/ssm` key, or recreate the parameter using a KMS key your role
+can decrypt.
+
+</details>
+
+<details>
+<summary>Check 8 failing — tags not found on environment parameter</summary>
+
+The SSM tagging API uses `--resource-id` with the parameter name, not the
+ARN. Verify the tags are set correctly:
+
+```bash
+aws ssm list-tags-for-resource \
+  --resource-type Parameter \
+  --resource-id /kata-109/config/environment
+```
+
+If the output shows no tags or wrong values, add or correct them:
+
+```bash
+aws ssm add-tags-to-resource \
+  --resource-type Parameter \
+  --resource-id /kata-109/config/environment \
+  --tags Key=Project,Value=CloudKata Key=Kata,Value=kata-109
+```
+
+</details>
+
+---
+
+## Still stuck?
+
+The complete working solution is in [solution.yml](./solution.yml).
+
+Deploy it with:
+
+```bash
+aws cloudformation deploy \
+  --template-file solution.yml \
+  --stack-name kata-109-solution \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+The `--capabilities CAPABILITY_NAMED_IAM` flag is required because the
+template creates an IAM role with an explicit name.
+
+Then re-run `validate.sh`. A correctly deployed solution should score 8/8.
+Study the solution to understand what you missed, then tear it down and try
+again from scratch.

--- a/katas/kata-109-ssm-parameter-store/README.md
+++ b/katas/kata-109-ssm-parameter-store/README.md
@@ -1,0 +1,184 @@
+---
+id: kata-109
+title: "SSM Parameter Store — Parameters, Types & Versioning"
+level: 100
+type: depth
+services:
+  - ssm
+tags:
+  - ssm
+  - parameter-store
+  - secrets
+  - depth
+  - foundational
+estimated_time: 30 minutes
+estimated_cost: "$0.00"
+author: Faisal Akhtar
+github: https://github.com/fakhtar
+---
+
+# kata-109 — SSM Parameter Store: Parameters, Types & Versioning
+
+## Overview
+
+In this kata you will create two SSM Parameter Store parameters of different
+types and explore how Parameter Store handles versioning. You will learn the
+difference between plaintext and encrypted parameter types, how parameters are
+named using path hierarchies, and how the version number changes each time a
+parameter is updated.
+
+---
+
+## Prerequisites
+
+- An active AWS account
+- Access to AWS CloudShell
+- IAM permissions to create and manage SSM Parameter Store parameters
+
+---
+
+## Cost & Time
+
+| | |
+|---|---|
+| ⏱ Estimated Time | ~30 minutes |
+| 💰 Estimated Cost | $0.00 |
+
+> ⚠️ **Cost Warning:** These are estimates only. SSM Parameter Store standard
+> parameters are free. SecureString parameters use AWS KMS for encryption —
+> using the AWS-managed key (`aws/ssm`) incurs no additional KMS charges for
+> standard-tier parameters. All charges are your responsibility. Always run
+> cleanup instructions when finished.
+
+---
+
+## Scenario
+
+Your team is migrating application configuration into Parameter Store. Two
+values need to be stored: a plaintext environment label that any service can
+read, and a sensitive API key that must be encrypted at rest. Your job is to
+provision both parameters in the correct format and verify that they are
+accessible and correctly typed.
+
+---
+
+## Requirements
+
+Build the following infrastructure in your AWS account. All parameter names
+must use the path prefix `/kata-109/`.
+
+You are given a spec, not a tutorial. Use the AWS Console, CLI, IaC, or any
+tools you choose to meet these requirements. Consult the AWS documentation,
+use AI assistants, or search the web — whatever you would use on the job.
+
+---
+
+### Requirement 1 — String Parameter
+
+Create a parameter at the path `/kata-109/config/environment` that stores a
+plaintext string value. The value must be `dev`.
+
+---
+
+### Requirement 2 — SecureString Parameter
+
+Create a parameter at the path `/kata-109/config/api-key` that stores a
+sensitive value encrypted at rest. The value must be `supersecret`.
+
+---
+
+### Requirement 3 — Versioning
+
+Update the `/kata-109/config/environment` parameter by changing its value to
+`staging`. The parameter must be at version 2 or higher when the validator
+runs.
+
+---
+
+### Requirement 4 — Tags
+
+Tag the `/kata-109/config/environment` parameter with the standard CloudKata tags:
+
+- `Project: CloudKata`
+- `Kata: kata-109`
+
+> **Note:** SecureString parameters have tagging constraints that make them
+> unsuitable for this kata. Only the String parameter is tagged.
+
+---
+
+## Running the Validator
+
+Once you have built the required infrastructure, open AWS CloudShell and
+upload or copy `validate.sh` to your CloudShell environment, then run:
+
+```bash
+sed -i 's/\r//' validate.sh
+chmod +x validate.sh
+./validate.sh
+```
+
+The validator checks your live AWS infrastructure and reports a score.
+A fully passing result looks like this:
+
+```
+==================================================
+ CloudKata Validator — kata-109
+ SSM Parameter Store: Parameters, Types & Versioning
+==================================================
+
+✅ PASS — Parameter '/kata-109/config/environment' exists
+✅ PASS — Parameter type is String
+✅ PASS — Parameter value is 'staging'
+✅ PASS — Parameter version is 2 or higher
+✅ PASS — Parameter '/kata-109/config/api-key' exists
+✅ PASS — Parameter type is SecureString
+✅ PASS — Parameter value is 'supersecret'
+✅ PASS — Required tags are present on '/kata-109/config/environment'
+
+==================================================
+ Results: 8/8 checks passed (100%)
+==================================================
+
+ 🎉 Perfect score! All kata-109 requirements met.
+```
+
+---
+
+## Cleanup
+
+Always clean up your resources when you are finished.
+
+### Step 1 — Delete CloudFormation stacks (if applicable)
+
+If you deployed `solution.yml`, delete that stack first via CloudFormation.
+
+```bash
+aws cloudformation delete-stack --stack-name kata-109-solution
+aws cloudformation wait stack-delete-complete --stack-name kata-109-solution
+```
+
+### Step 2 — Manual Cleanup
+
+If you created parameters manually:
+
+```bash
+aws ssm delete-parameter --name /kata-109/config/environment
+aws ssm delete-parameter --name /kata-109/config/api-key
+```
+
+### Step 3 — Verify in the console
+
+Confirm that neither parameter appears in the Systems Manager Parameter Store
+console under the `/kata-109/` path.
+
+---
+
+## Hints & Solution
+
+Stuck? Refer to [HINTS.md](./HINTS.md) for progressive hints without full
+spoilers.
+
+The complete solution is available in [solution.yml](./solution.yml).
+Deploying `solution.yml` and re-running `validate.sh` should produce a
+score of 100%.

--- a/katas/kata-109-ssm-parameter-store/solution.yml
+++ b/katas/kata-109-ssm-parameter-store/solution.yml
@@ -1,0 +1,211 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  CloudKata kata-109 - SSM Parameter Store: Parameters, Types & Versioning.
+  Creates /kata-109/config/environment (String, value: staging, version >= 2)
+  and /kata-109/config/api-key (SecureString, value: supersecret) with
+  standard CloudKata tags on both parameters.
+
+# ==============================================================================
+# Resources
+# ==============================================================================
+Resources:
+
+  # ----------------------------------------------------------------------------
+  # String Parameter — /kata-109/config/environment
+  #
+  # AWS::SSM::Parameter supports String and StringList types natively.
+  # Value is set to "staging" directly. The version counter is driven to 2
+  # by the ParameterVersionBump custom resource below.
+  #
+  # Tags in CloudFormation use a flat map {Key: Value}, not a list.
+  # CloudFormation also automatically adds three aws:cloudformation:* tags.
+  # ----------------------------------------------------------------------------
+  EnvironmentParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /kata-109/config/environment
+      Type: String
+      Value: staging
+      Description: "kata-109 environment label"
+      Tags:
+        Project: CloudKata
+        Kata: kata-109
+
+  # ----------------------------------------------------------------------------
+  # IAM Role for custom resource Lambda functions
+  #
+  # Grants:
+  #   - AWSLambdaBasicExecutionRole (CloudWatch Logs)
+  #   - ssm:PutParameter on both parameter ARNs
+  #   - ssm:DeleteParameter on the SecureString parameter ARN
+  #
+  # The environment parameter does not need ssm:DeleteParameter because
+  # AWS::SSM::Parameter handles its own deletion on stack teardown.
+  # The SecureString parameter is managed entirely by the custom resource
+  # and must be explicitly cleaned up on Delete.
+  # ----------------------------------------------------------------------------
+  CustomResourceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: kata-109-CustomResourceRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: kata-109-SSMAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:PutParameter
+                  - ssm:DeleteParameter
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                Resource:
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/kata-109/config/environment"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/kata-109/config/api-key"
+
+  # ----------------------------------------------------------------------------
+  # Lambda — VersionBumpFunction
+  #
+  # Writes the environment parameter a second time (Overwrite=True) to advance
+  # the version counter from 1 to 2. Called by ParameterVersionBump below.
+  #
+  # Handles Create and Update by calling PutParameter with the same value.
+  # Handles Delete as a no-op — the parameter itself is managed by
+  # AWS::SSM::Parameter and deleted automatically on stack teardown.
+  # ----------------------------------------------------------------------------
+  VersionBumpFunction:
+    Type: AWS::Lambda::Function
+    DependsOn: EnvironmentParameter
+    Properties:
+      FunctionName: kata-109-VersionBumpFunction
+      Runtime: python3.12
+      Handler: index.handler
+      Role: !GetAtt CustomResourceRole.Arn
+      Timeout: 30
+      Code:
+        ZipFile: |
+          import boto3
+          import cfnresponse
+
+          ssm = boto3.client("ssm")
+
+          def handler(event, context):
+              try:
+                  if event["RequestType"] in ("Create", "Update"):
+                      ssm.put_parameter(
+                          Name="/kata-109/config/environment",
+                          Value="staging",
+                          Type="String",
+                          Overwrite=True
+                      )
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+              except Exception as e:
+                  print(e)
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {"Error": str(e)})
+
+  # ----------------------------------------------------------------------------
+  # Custom Resource — ParameterVersionBump
+  #
+  # Triggers VersionBumpFunction on stack creation to write the environment
+  # parameter a second time, advancing its version to 2. DependsOn ensures
+  # the parameter exists before the bump runs.
+  # ----------------------------------------------------------------------------
+  ParameterVersionBump:
+    Type: Custom::ParameterVersionBump
+    DependsOn: EnvironmentParameter
+    Properties:
+      ServiceToken: !GetAtt VersionBumpFunction.Arn
+
+  # ----------------------------------------------------------------------------
+  # Lambda — SecureStringFunction
+  #
+  # Creates and manages /kata-109/config/api-key as a SecureString.
+  # AWS::SSM::Parameter does not support SecureString, so a custom resource
+  # is required.
+  #
+  # On Create/Update: calls PutParameter with Type=SecureString and
+  # The parameter is created without tags — SecureString tagging is not
+  # supported in this kata due to API constraints.
+  # On Delete: calls DeleteParameter to clean up the parameter on stack
+  # teardown (it would otherwise be orphaned).
+  #
+  # Uses the default AWS-managed KMS key (aws/ssm) — no customer-managed
+  # key is required for this kata.
+  # ----------------------------------------------------------------------------
+  SecureStringFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: kata-109-SecureStringFunction
+      Runtime: python3.12
+      Handler: index.handler
+      Role: !GetAtt CustomResourceRole.Arn
+      Timeout: 30
+      Code:
+        ZipFile: |
+          import boto3
+          import cfnresponse
+
+          ssm = boto3.client("ssm")
+          PARAM_NAME = "/kata-109/config/api-key"
+
+          def handler(event, context):
+              try:
+                  request_type = event["RequestType"]
+
+                  if request_type in ("Create", "Update"):
+                      ssm.put_parameter(
+                          Name=PARAM_NAME,
+                          Value="supersecret",
+                          Type="SecureString",
+                          Overwrite=True
+                      )
+
+                  elif request_type == "Delete":
+                      try:
+                          ssm.delete_parameter(Name=PARAM_NAME)
+                      except ssm.exceptions.ParameterNotFound:
+                          pass
+
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, PARAM_NAME)
+              except Exception as e:
+                  print(e)
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {"Error": str(e)}, PARAM_NAME)
+
+  # ----------------------------------------------------------------------------
+  # Custom Resource — SecureStringParameter
+  #
+  # Invokes SecureStringFunction to create /kata-109/config/api-key.
+  # ----------------------------------------------------------------------------
+  SecureStringParameter:
+    Type: Custom::SecureStringParameter
+    Properties:
+      ServiceToken: !GetAtt SecureStringFunction.Arn
+
+# ==============================================================================
+# Outputs
+# ==============================================================================
+Outputs:
+  EnvironmentParameterName:
+    Description: Name of the String parameter
+    Value: !Ref EnvironmentParameter
+
+  EnvironmentParameterVersion:
+    Description: Current version of the environment parameter (should be 2+)
+    Value: !GetAtt EnvironmentParameter.Value
+
+  SecureStringParameterName:
+    Description: Name of the SecureString parameter
+    Value: /kata-109/config/api-key
+
+  ValidatorInstructions:
+    Description: How to validate this kata
+    Value: "Run validate.sh in AWS CloudShell after deploying this stack"

--- a/katas/kata-109-ssm-parameter-store/validate.sh
+++ b/katas/kata-109-ssm-parameter-store/validate.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+# ==============================================================================
+# CloudKata Validator — kata-109
+# SSM Parameter Store: Parameters, Types & Versioning
+# ==============================================================================
+
+PARAM_ENV="/kata-109/config/environment"
+PARAM_KEY="/kata-109/config/api-key"
+EXPECTED_ENV_VALUE="staging"
+EXPECTED_KEY_VALUE="supersecret"
+EXPECTED_ENV_TYPE="String"
+EXPECTED_KEY_TYPE="SecureString"
+TOTAL_CHECKS=8
+
+PASS=0
+FAIL=0
+
+pass() { echo "✅ PASS — $1"; ((PASS++)); }
+fail() { echo "❌ FAIL — $1"; ((FAIL++)); }
+
+echo ""
+echo "=================================================="
+echo " CloudKata Validator — kata-109"
+echo " SSM Parameter Store: Parameters, Types & Versioning"
+echo "=================================================="
+echo ""
+
+# ------------------------------------------------------------------------------
+# Check 1 — String parameter exists (hard gate for checks 2-4)
+# ------------------------------------------------------------------------------
+echo "Checking parameter '$PARAM_ENV'..."
+ENV_JSON=$(aws ssm get-parameter \
+  --name "$PARAM_ENV" \
+  --output json 2>/dev/null)
+
+if [ -z "$ENV_JSON" ] || [ "$ENV_JSON" = "null" ]; then
+  fail "Parameter '$PARAM_ENV' not found"
+  fail "Parameter type could not be checked — parameter not found"
+  fail "Parameter value could not be checked — parameter not found"
+  fail "Parameter version could not be checked — parameter not found"
+else
+  pass "Parameter '$PARAM_ENV' exists"
+
+  ENV_TYPE=$(echo "$ENV_JSON" | jq -r '.Parameter.Type // empty')
+  ENV_VALUE=$(echo "$ENV_JSON" | jq -r '.Parameter.Value // empty')
+  ENV_VERSION=$(echo "$ENV_JSON" | jq -r '.Parameter.Version // 0')
+
+  # ----------------------------------------------------------------------------
+  # Check 2 — String parameter type is String
+  # ----------------------------------------------------------------------------
+  if [ "$ENV_TYPE" = "$EXPECTED_ENV_TYPE" ]; then
+    pass "Parameter type is String"
+  else
+    fail "Parameter type is '$ENV_TYPE' — expected '$EXPECTED_ENV_TYPE'"
+  fi
+
+  # ----------------------------------------------------------------------------
+  # Check 3 — String parameter value is 'staging'
+  # ----------------------------------------------------------------------------
+  if [ "$ENV_VALUE" = "$EXPECTED_ENV_VALUE" ]; then
+    pass "Parameter value is '$EXPECTED_ENV_VALUE'"
+  else
+    fail "Parameter value is '$ENV_VALUE' — expected '$EXPECTED_ENV_VALUE' (have you updated the parameter after creating it?)"
+  fi
+
+  # ----------------------------------------------------------------------------
+  # Check 4 — String parameter version is 2 or higher
+  # ----------------------------------------------------------------------------
+  if [ "$ENV_VERSION" -ge 2 ] 2>/dev/null; then
+    pass "Parameter version is $ENV_VERSION (version 2 or higher)"
+  else
+    fail "Parameter version is $ENV_VERSION — expected 2 or higher (update the parameter value to increment the version)"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 5 — SecureString parameter exists (hard gate for checks 6-7)
+# ------------------------------------------------------------------------------
+echo "Checking parameter '$PARAM_KEY'..."
+KEY_JSON=$(aws ssm get-parameter \
+  --name "$PARAM_KEY" \
+  --with-decryption \
+  --output json 2>/dev/null)
+
+if [ -z "$KEY_JSON" ] || [ "$KEY_JSON" = "null" ]; then
+  fail "Parameter '$PARAM_KEY' not found"
+  fail "Parameter type could not be checked — parameter not found"
+  fail "Parameter value could not be checked — parameter not found"
+else
+  pass "Parameter '$PARAM_KEY' exists"
+
+  KEY_TYPE=$(echo "$KEY_JSON" | jq -r '.Parameter.Type // empty')
+  KEY_VALUE=$(echo "$KEY_JSON" | jq -r '.Parameter.Value // empty')
+
+  # ----------------------------------------------------------------------------
+  # Check 6 — SecureString parameter type is SecureString
+  # ----------------------------------------------------------------------------
+  if [ "$KEY_TYPE" = "$EXPECTED_KEY_TYPE" ]; then
+    pass "Parameter type is SecureString"
+  else
+    fail "Parameter type is '$KEY_TYPE' — expected '$EXPECTED_KEY_TYPE'"
+  fi
+
+  # ----------------------------------------------------------------------------
+  # Check 7 — SecureString parameter value is 'supersecret'
+  # ----------------------------------------------------------------------------
+  if [ "$KEY_VALUE" = "$EXPECTED_KEY_VALUE" ]; then
+    pass "Parameter value is '$EXPECTED_KEY_VALUE'"
+  else
+    fail "Parameter value is incorrect — expected '$EXPECTED_KEY_VALUE'"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 8 — Required tags on String parameter
+#
+# SSM list-tags-for-resource uses --resource-type Parameter and
+# --resource-id <parameter-name> (not ARN). Returns {"TagList": [{Key, Value}]}
+# — array format, requires jq select() pattern.
+# ------------------------------------------------------------------------------
+echo "Checking tags on '$PARAM_ENV'..."
+ENV_TAGS=$(aws ssm list-tags-for-resource \
+  --resource-type Parameter \
+  --resource-id "$PARAM_ENV" \
+  --output json 2>/dev/null)
+
+ENV_PROJECT=$(echo "$ENV_TAGS" | jq -r '.TagList[] | select(.Key=="Project") | .Value' 2>/dev/null)
+ENV_KATA=$(echo "$ENV_TAGS" | jq -r '.TagList[] | select(.Key=="Kata") | .Value' 2>/dev/null)
+
+if [ "$ENV_PROJECT" = "CloudKata" ] && [ "$ENV_KATA" = "kata-109" ]; then
+  pass "Required tags are present on '$PARAM_ENV'"
+else
+  MISSING=""
+  [ "$ENV_PROJECT" != "CloudKata" ] && MISSING="Project: CloudKata "
+  [ "$ENV_KATA" != "kata-109" ] && MISSING="${MISSING}Kata: kata-109"
+  fail "Missing or incorrect tags on '$PARAM_ENV': $MISSING"
+fi
+
+# ------------------------------------------------------------------------------
+# Results
+# ------------------------------------------------------------------------------
+PCT=$(( (PASS * 100) / TOTAL_CHECKS ))
+
+echo ""
+echo "=================================================="
+echo " Results: $PASS/$TOTAL_CHECKS checks passed ($PCT%)"
+echo "=================================================="
+
+if [ "$PASS" -eq "$TOTAL_CHECKS" ]; then
+  echo " 🎉 Perfect score! All kata-109 requirements met."
+elif [ "$PASS" -ge 5 ]; then
+  echo " 🔧 Almost there — review the failed checks above."
+else
+  echo " 📖 Keep going — consult HINTS.md for guidance."
+fi
+echo ""


### PR DESCRIPTION
Introduces kata-109, a depth-level 100 kata covering SSM Parameter Store fundamentals. Learners create a String parameter and a SecureString parameter under a path hierarchy, experience the versioning lifecycle by updating a parameter, and verify tags on the String parameter. This is the first kata in the library to require a CloudFormation custom resource due to a native service limitation.

---

Requirements are written at spec level. Key decisions:

- Requirement 1 names the parameter path and type as String with value `dev`. The initial value `dev` is deliberate — creating with `dev` then updating to `staging` is what teaches the versioning behaviour. Creating directly with `staging` would force a second meaningless overwrite to satisfy the version check.
- Requirement 2 names the path and states the value must be encrypted at rest, without naming SecureString, KMS, or the aws/ssm key.
- Requirement 3 states the parameter must be at version 2 or higher — not that the learner must call put-parameter twice. The learner works out that updating a parameter increments its version.
- Requirement 4 tags only the String parameter. SecureString tagging is explicitly excluded with a note explaining API constraints. This was a deliberate scope reduction after live deployment revealed that add-tags-to-resource calls ssm:GetParameters as an undocumented internal validation step, and that put-parameter rejects Tags= when Overwrite=True is also set — making SecureString tagging via CloudFormation prohibitively complex for a 100-level kata.
- Validator output block shows 8/8 checks, matching the reduced scope.

---

8 checks across two independent parameter gates.

Check structure:
  1.  /kata-109/config/environment exists (hard gate for checks 2-4)
  2.  Parameter type is String
  3.  Parameter value is 'staging'
  4.  Parameter version is >= 2
  5.  /kata-109/config/api-key exists (hard gate for checks 6-7)
  6.  Parameter type is SecureString
  7.  Parameter value is 'supersecret'
  8.  Required tags present on /kata-109/config/environment

Key implementation notes:
- SecureString retrieved with --with-decryption so the plaintext value can be compared. Without this flag the value is returned as an encrypted blob and check 7 would always fail.
- Version check uses -ge 2 with 2>/dev/null guard against non-numeric values.
- Check 3 failure message includes a parenthetical hint about updating the parameter, since creating directly with 'staging' is the most common cause.
- Tag check uses aws ssm list-tags-for-resource --resource-type Parameter --resource-id <name> (not ARN). Returns {"TagList": [{Key, Value}]} array — jq select() pattern, same as DynamoDB and Connect, not the flat map used by Lambda/APIGW.
- Two separate hard gates (environment and api-key) so a missing api-key does not block the environment tag check.
- bash -n syntax check passes clean.

---

6 resources. Requires --capabilities CAPABILITY_NAMED_IAM.

Resources:
  - AWS::SSM::Parameter (EnvironmentParameter) /kata-109/config/environment, Type: String, Value: staging. Tags use flat map {Key: Value} — not a list. CloudFormation adds three aws:cloudformation:* tags automatically in addition to the custom tags.

  - AWS::IAM::Role (kata-109-CustomResourceRole) Single policy statement with ssm:PutParameter, ssm:DeleteParameter, ssm:GetParameter, ssm:GetParameters scoped to both parameter ARNs. The policy was consolidated from two statements into one after live deployment revealed that add-tags-to-resource triggers an undocumented ssm:GetParameters call that was missing from the narrower second statement in the original design.

  - AWS::Lambda::Function (kata-109-VersionBumpFunction) Calls ssm:PutParameter with Overwrite=True on the environment parameter to advance its version from 1 to 2. DependsOn: EnvironmentParameter ensures the parameter exists before the function is created. Handles Delete as a no-op since AWS::SSM::Parameter manages its own lifecycle.

  - Custom::ParameterVersionBump (ParameterVersionBump) Triggers VersionBumpFunction on Create/Update. DependsOn: EnvironmentParameter to prevent a race where the bump fires before the parameter is created.

  - AWS::Lambda::Function (kata-109-SecureStringFunction) Creates /kata-109/config/api-key as SecureString via ssm:PutParameter — the only viable approach since AWS::SSM::Parameter does not support Type: SecureString (open CFN issue since 2019). Uses the default aws/ssm KMS key. On Delete: calls ssm:DeleteParameter wrapped in a ParameterNotFound catch so stack teardown never fails on an already-deleted parameter. No tags are applied — SecureString tagging excluded after live deployment failures: - put-parameter rejects Tags= when Overwrite=True is set (ValidationException: tags and overwrite can't be used together) - add-tags-to-resource internally calls ssm:GetParameters as an undocumented validation step, causing AccessDeniedException even after the action was added to the IAM policy, because the old Lambda code was reused from the prior failed stack

  - Custom::SecureStringParameter (SecureStringParameter) Invokes SecureStringFunction.

---

Three-level progressive hints for all four requirements. All implementation specifics appear only at Hint 3.

Notable hint design decisions:
- Req 1 Hint 3 instructs learners to create with value 'dev' first, explaining why — to teach the version increment behaviour naturally.
- Req 2 Hint 3 explicitly documents the CloudFormation SecureString limitation and points to solution.yml rather than leaving learners to discover the schema rejection themselves.
- Req 3 Hint 3 includes the version verification CLI command so learners can confirm their state before running the validator.
- Req 4 Hint 2 explains the SSM-specific tagging API surface (add-tags-to-resource with --resource-type Parameter and --resource-id <name>, not ARN) since it differs from tagging patterns learners encounter with other services.
- Troubleshooting check 7 covers the kms:Decrypt edge case where --with-decryption fails if CloudShell's role lacks the permission, returning a ciphertext blob instead of the plaintext value.
- Troubleshooting check 4 includes the same-value overwrite trick for learners who created the parameter directly with 'staging' and need to reach version 2 without changing the value.

Closes #22 