### PR TITLE
Add kata-204: S3 + Lambda — Event Notifications & Triggers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -537,7 +537,7 @@ The following katas are planned for the CloudKata library. All are open for comm
 | [kata-201](./katas/kata-201-dynamodb-core/) | DynamoDB Core — Tables, Keys, Indexes & Capacity Modes | 200 | Depth | DynamoDB | Published |
 | [kata-202](./katas/kata-202-lexv2-advanced/) | Amazon Lex V2 Advanced — Versioning, Aliases & Lambda Fulfillment | 200 | Depth | Lex V2, Lambda | Published |
 | [kata-203](./katas/kata-203-api-gateway-lambda-rest/)   | API Gateway + Lambda — REST API & Proxy Integration | 200 | Breadth | API Gateway, Lambda | Published |
-| kata-204 | S3 + Lambda — Event Notifications & Triggers | 200 | Breadth | S3, Lambda | Open |
+| [kata-204](./katas/kata-204-lambda-event-notification-and-triggers/) | S3 + Lambda — Event Notifications & Triggers | 200 | Breadth | S3, Lambda | Open |
 | kata-205 | Lambda + SQS — Event Source Mapping & Error Handling | 200 | Breadth | Lambda, SQS | Open |
 | kata-206 | RDS Basics — Instances, Subnet Groups & Parameter Groups | 200 | Depth | RDS | Open |
 | [kata-207](./katas/kata-207-cloudtrail-basics/)  | CloudTrail Basics — Trails, Events & Audit Logging | 200 | Depth | CloudTrail, S3 | Published |

--- a/katas/kata-204-lambda-event-notification-and-triggers/HINTS.md
+++ b/katas/kata-204-lambda-event-notification-and-triggers/HINTS.md
@@ -1,0 +1,393 @@
+# kata-204 Hints — S3 + Lambda: Event Notifications & Triggers
+
+> ⚠️ **Spoiler warning.** Each hint section reveals progressively more detail.
+> Try to solve each requirement on your own before opening a hint. The learning
+> is in the struggle.
+
+---
+
+## How to use these hints
+
+Hints are organized by requirement number matching the README. Each requirement
+has up to three levels:
+
+- **Hint 1** — a nudge in the right direction
+- **Hint 2** — more specific guidance
+- **Hint 3** — the exact approach (near-solution level)
+
+---
+
+## Requirement 1 — S3 Bucket
+
+<details>
+<summary>Hint 1 — Where to start</summary>
+
+S3 bucket names are global — unique across every AWS account on the
+internet, not just your own. A bucket literally named `kata-204-bucket-`
+will almost certainly already exist (or be rejected for other reasons), so
+you need to append something to the prefix to make it unique.
+
+</details>
+
+<details>
+<summary>Hint 2 — What to append</summary>
+
+Your AWS account ID is a reliable, simple choice for the unique suffix —
+it's already unique to you, it's stable, and it makes the bucket easy to
+identify later. You can find it with:
+
+```bash
+aws sts get-caller-identity --query Account --output text
+```
+
+A bucket named `kata-204-bucket-<your-account-id>` satisfies the
+requirement: it starts with the required prefix, and the suffix guarantees
+no collision with anyone else's bucket.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact creation command</summary>
+
+```bash
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+aws s3api create-bucket \
+  --bucket "kata-204-bucket-${ACCOUNT_ID}" \
+  --region us-east-1
+```
+
+> If your region is not `us-east-1`, `create-bucket` requires an additional
+> `--create-bucket-configuration LocationConstraint=<your-region>` argument
+> — `us-east-1` is the one region that does not need this.
+
+In CloudFormation, set `BucketName` to an explicit, predictable string
+rather than omitting it (which would let CloudFormation auto-generate a
+name). This matters more than it looks like it should — see Requirement 4,
+Hint 3 for why.
+
+</details>
+
+---
+
+## Requirement 2 — Lambda Function
+
+<details>
+<summary>Hint 1 — Where to start</summary>
+
+You don't need to write any function logic — the README gives you the
+exact code to use. Your job here is just getting that code deployed under
+the right name, runtime, and role. If you're using the console, the
+"Author from scratch" option with the Python 3.12 runtime gets you there
+fastest.
+
+</details>
+
+<details>
+<summary>Hint 2 — Execution role</summary>
+
+Every Lambda function needs an execution role — an IAM role the Lambda
+service assumes when running your code. For this kata, the function only
+needs to write its own logs; it never calls any S3 API itself (it just
+reads the event data S3 hands it). If you're creating the role via the
+console, "Create a new role with basic Lambda permissions" gives you
+exactly this. Via CLI or IaC, the standard
+`AWSLambdaBasicExecutionRole` managed policy is exactly scoped for this —
+nothing more is required.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact configuration and gotcha</summary>
+
+- **Function name:** `kata-204-ProcessorFunction` — exact match required
+- **Runtime:** `python3.12`
+- **Handler:** `index.handler` if your code file is named `index.py` and
+  the function inside it is named `handler` (matching the README's
+  provided code as-is)
+- **Timeout:** the default of 3 seconds is technically enough for this
+  function, but set it to 10+ seconds anyway — cold starts plus a slow
+  CloudShell network round-trip have caused enough flaky timeouts in this
+  kata that the small buffer is worth it
+
+Via CLI:
+```bash
+aws iam create-role \
+  --role-name kata-204-ProcessorFunctionRole \
+  --assume-role-policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": {"Service": "lambda.amazonaws.com"},
+      "Action": "sts:AssumeRole"
+    }]
+  }'
+
+aws iam attach-role-policy \
+  --role-name kata-204-ProcessorFunctionRole \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+# Wait a few seconds for IAM role propagation before creating the function,
+# or you'll get an "InvalidParameterValueException: role cannot be assumed"
+# error even though the role clearly exists.
+
+zip function.zip index.py
+aws lambda create-function \
+  --function-name kata-204-ProcessorFunction \
+  --runtime python3.12 \
+  --handler index.handler \
+  --role "arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):role/kata-204-ProcessorFunctionRole" \
+  --zip-file fileb://function.zip \
+  --timeout 10
+```
+
+In CloudFormation, `AWS::Lambda::Function` with an inline `ZipFile` under
+`Code` avoids needing to upload a zip to S3 first — fine for a function
+this small.
+
+</details>
+
+---
+
+## Requirement 3 — S3 Event Notification
+
+<details>
+<summary>Hint 1 — Where this configuration lives</summary>
+
+S3 event notifications are a property of the bucket itself, not of the
+Lambda function. In the console, this is under your bucket → **Properties**
+tab → **Event notifications** → **Create event notification**. There's no
+separate "trigger" resource to create — you're configuring the bucket to
+call out to Lambda.
+
+</details>
+
+<details>
+<summary>Hint 2 — Event type selection</summary>
+
+S3 offers many granular event types (`s3:ObjectCreated:Put`,
+`s3:ObjectCreated:Post`, `s3:ObjectCreated:Copy`, etc.) as well as the
+wildcard `s3:ObjectCreated:*`, which covers all of them. Use the wildcard
+— it's what the README and validator both expect, and it means your
+trigger fires regardless of how an object gets created (regular upload,
+multipart upload completion, copy from another bucket, and so on).
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact CLI command and CFN property name</summary>
+
+Via CLI (this replaces the *entire* notification configuration, so if you
+already have other notifications configured, fetch and merge them first
+rather than overwriting):
+
+```bash
+aws s3api put-bucket-notification-configuration \
+  --bucket "kata-204-bucket-${ACCOUNT_ID}" \
+  --notification-configuration '{
+    "LambdaFunctionConfigurations": [
+      {
+        "LambdaFunctionArn": "arn:aws:lambda:'"${REGION}"':'"${ACCOUNT_ID}"':function:kata-204-ProcessorFunction",
+        "Events": ["s3:ObjectCreated:*"]
+      }
+    ]
+  }'
+```
+
+> **This will fail with `InvalidArgument: Unable to validate the following
+> destination configurations`** if Requirement 4 (the Lambda permission)
+> isn't already in place. S3 checks, at the moment you submit this
+> configuration, that the target function's resource policy already
+> grants S3 permission to invoke it — it will not let you configure the
+> notification first and grant permission second. Do Requirement 4 before
+> this step, or your `put-bucket-notification-configuration` call will be
+> rejected outright with a clear error (this one is loud, not silent).
+
+In CloudFormation, the property is `NotificationConfiguration` on
+`AWS::S3::Bucket`, with a `LambdaConfigurations` list. Each entry uses the
+singular key `Event` (not `Events`) and a `Function` key for the ARN:
+
+```yaml
+NotificationConfiguration:
+  LambdaConfigurations:
+    - Event: "s3:ObjectCreated:*"
+      Function: !GetAtt YourFunction.Arn
+```
+
+</details>
+
+---
+
+## Requirement 4 — Permission to Invoke
+
+<details>
+<summary>Hint 1 — Why this is a separate step at all</summary>
+
+Configuring the event notification on the bucket (Requirement 3) only
+tells S3 *what* to call. It does not, by itself, give S3 permission to
+call it — Lambda functions are private by default and only respond to
+invocations from principals explicitly authorized via the function's own
+resource-based policy (separate from the function's execution role, which
+controls what the function can do, not who can invoke it). This is the
+single most commonly missed step in S3-to-Lambda wiring, precisely because
+nothing about Requirement 3 visibly fails if you skip it — well, almost
+nothing; see Hint 3 below.
+
+</details>
+
+<details>
+<summary>Hint 2 — What "scoped to your bucket" means</summary>
+
+It's not enough to allow the S3 service in general — that would let *any*
+S3 bucket in *any* AWS account invoke your function, since `s3.amazonaws.com`
+on its own is just "the S3 service," not "my bucket." You need to add a
+condition that restricts the grant to your specific bucket's ARN. In the
+Lambda console, when you add a trigger from the function's **Configuration
+→ Triggers** tab and select S3, this scoping is handled for you
+automatically — but if you're doing this manually via the CLI or IaC, you
+have to specify it yourself.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact CLI command and the CloudFormation circular dependency</summary>
+
+Via CLI:
+```bash
+aws lambda add-permission \
+  --function-name kata-204-ProcessorFunction \
+  --statement-id AllowS3Invoke \
+  --action lambda:InvokeFunction \
+  --principal s3.amazonaws.com \
+  --source-arn "arn:aws:s3:::kata-204-bucket-${ACCOUNT_ID}" \
+  --source-account "${ACCOUNT_ID}"
+```
+
+The `--source-arn` is what scopes the grant to this one bucket. Without
+it, the statement would allow `s3.amazonaws.com` unconditionally — which
+satisfies "S3 can invoke the function" but fails "scoped to your bucket
+specifically," since it would technically permit any bucket, in any
+account, to invoke your function. `--source-account` is good practice
+alongside it: it guards against the edge case where a bucket with the same
+name is deleted and later recreated by a different AWS account.
+
+**If you're using CloudFormation**, this requirement runs straight into a
+well-known circular dependency. The natural way to write this is to give
+`AWS::Lambda::Permission`'s `SourceArn` a `!GetAtt YourBucket.Arn`
+reference — but your bucket's `NotificationConfiguration` (Requirement 3)
+needs `!GetAtt YourFunction.Arn`, and now the permission depends on the
+bucket while the bucket depends on the function depends on... nothing
+depends on the permission, except that S3 won't accept the notification
+config without it. CloudFormation can't find a valid creation order and
+will reject the template outright with a dependency error before it even
+attempts to deploy.
+
+The way out: don't let CloudFormation auto-generate your bucket's name.
+Give the bucket an explicit `BucketName` (see Requirement 1, Hint 3), and
+build the bucket's ARN as a plain string with `!Sub` in your
+`AWS::Lambda::Permission`'s `SourceArn` — for example
+`!Sub "arn:aws:s3:::kata-204-bucket-${AWS::AccountId}"` — instead of
+referencing the bucket resource directly. Since the permission no longer
+references the bucket resource at all, there's no cycle: the permission
+can be created right after the function, and the bucket (which still
+needs both the permission and the function) goes last. Add an explicit
+`DependsOn` from the bucket to the permission resource to guarantee
+CloudFormation enforces that order, since the bucket's only *reference* to
+the permission is implicit otherwise.
+
+</details>
+
+---
+
+## General Troubleshooting
+
+<details>
+<summary>S3 rejects my notification configuration before I even finish Requirement 3</summary>
+
+This means you're hitting Requirement 3 before Requirement 4 — S3
+validates, at the moment you submit a Lambda notification configuration,
+that the target function already has a resource policy granting S3
+invoke permission. Go set up the permission first (Requirement 4), then
+come back and configure the notification.
+
+</details>
+
+<details>
+<summary>Everything looks correctly configured but nothing happens when I upload a file</summary>
+
+Work through these in order — they're the only four things that can break
+this wiring, and they fail silently in this order of likelihood:
+
+1. Check the resource policy actually exists and is scoped to the right
+   bucket:
+   ```bash
+   aws lambda get-policy --function-name kata-204-ProcessorFunction --query Policy --output text | jq .
+   ```
+   Look for a statement with `"Service": "s3.amazonaws.com"` and a
+   `Condition.ArnLike."AWS:SourceArn"` matching your bucket's ARN exactly.
+   A missing `SourceArn` condition (the function is invocable, just not
+   scoped) won't cause a missed invocation — but a *wrong* bucket ARN in
+   that condition will.
+
+2. Check the notification configuration is still attached to the function
+   you think it is:
+   ```bash
+   aws s3api get-bucket-notification-configuration --bucket kata-204-bucket-<your-account-id>
+   ```
+   Confirm `LambdaFunctionArn` points at `kata-204-ProcessorFunction` and
+   `Events` includes an `s3:ObjectCreated` entry. If you edited the bucket
+   or redeployed a stack since you last tested, double check this wasn't
+   silently dropped or overwritten — `put-bucket-notification-configuration`
+   replaces the *entire* configuration, so a second call without merging
+   the first can wipe out what you set up earlier.
+
+3. Check you're uploading to the bucket the notification is actually
+   configured on — easy to mix up if you created more than one bucket
+   while experimenting.
+
+4. If you're doing the optional manual check from the README, check
+   CloudWatch Logs directly for the invocation rather than trusting that
+   "no errors visible" means "nothing happened" (the validator itself
+   does not check this — only the optional self-check does):
+   ```bash
+   aws logs tail /aws/lambda/kata-204-ProcessorFunction --since 5m
+   ```
+   S3 event delivery is asynchronous and occasionally takes longer than
+   you'd expect even when everything is wired correctly — if you see your
+   upload's invocation in the logs a little later than you expected, the
+   wiring was fine all along and this was just a timing illusion, not a
+   bug.
+
+</details>
+
+<details>
+<summary>I get an "AccessDenied" or similar error when uploading to my own bucket</summary>
+
+This is unrelated to the Lambda wiring — it means your own IAM identity
+(the one running `aws s3 cp`) doesn't have `s3:PutObject` permission on
+the bucket, which is a separate concern from the bucket's notification
+configuration or the Lambda's resource policy. Check the permissions
+attached to the IAM user or role you're using in CloudShell.
+
+</details>
+
+---
+
+## Still stuck?
+
+The complete working solution is in [solution.yml](./solution.yml).
+
+Deploy it with:
+
+```bash
+aws cloudformation deploy \
+  --template-file solution.yml \
+  --stack-name kata-204-solution \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+The `--capabilities CAPABILITY_NAMED_IAM` flag is required because the
+template creates an IAM role with an explicit name.
+
+Then re-run `validate.sh`. A correctly deployed solution should score 7/7.
+Study the solution to understand what you missed, then tear it down and
+try again from scratch.

--- a/katas/kata-204-lambda-event-notification-and-triggers/README.md
+++ b/katas/kata-204-lambda-event-notification-and-triggers/README.md
@@ -1,0 +1,277 @@
+---
+id: kata-204
+title: "S3 + Lambda — Event Notifications & Triggers"
+level: 200
+type: breadth
+services:
+  - s3
+  - lambda
+tags:
+  - s3
+  - lambda
+  - event-driven
+  - notifications
+  - triggers
+  - breadth
+  - intermediate
+estimated_time: 45 minutes
+estimated_cost: "$0.00"
+author: Faisal Akhtar
+github: https://github.com/fakhtar
+---
+
+# kata-204 — S3 + Lambda: Event Notifications & Triggers
+
+## Overview
+
+In this kata you will build an event-driven architecture where uploading an
+object to an S3 bucket automatically triggers a Lambda function. You will
+configure an S3 event notification and grant S3 permission to invoke your
+function via a resource-based policy — the exact wiring behind nearly every
+S3-triggered serverless workflow: image processing pipelines, file
+ingestion, log shipping, and more.
+
+This is not a coding kata. The Lambda function code is provided for you
+below — your job is the infrastructure and the event wiring around it.
+
+---
+
+## Prerequisites
+
+- An active AWS account
+- Access to AWS CloudShell
+- IAM permissions to create and manage S3 buckets, Lambda functions, IAM
+  roles, and CloudWatch Logs
+
+---
+
+## Cost & Time
+
+| | |
+|---|---|
+| ⏱ Estimated Time | ~45 minutes |
+| 💰 Estimated Cost | $0.00 |
+
+> ⚠️ **Cost Warning:** These are estimates only. S3 storage and requests,
+> Lambda invocations, and CloudWatch Logs all have a perpetual free tier
+> that easily covers this kata. Actual costs depend on your AWS region,
+> account tier, and how quickly you complete the kata. All charges are
+> your responsibility. Always run cleanup instructions when finished.
+
+---
+
+## Scenario
+
+Your team needs a lightweight ingestion pipeline: whenever a file is
+uploaded to a specific S3 bucket, a Lambda function should run automatically
+to process it. For this kata, "processing" simply means logging details
+about the uploaded object — but the wiring you build here is the same
+wiring used in production ingestion pipelines that resize images, parse
+CSVs, or kick off downstream workflows.
+
+---
+
+## Provided Lambda Function Code
+
+You do not need to write any function logic for this kata. Use the
+following Python 3.12 code as the Lambda function's source. It logs the
+bucket name, object key, and event name for every record in the S3 event.
+
+```python
+import json
+
+def handler(event, context):
+    print("kata-204 ProcessorFunction invoked")
+    print(json.dumps(event))
+
+    for record in event.get("Records", []):
+        bucket = record.get("s3", {}).get("bucket", {}).get("name", "unknown-bucket")
+        key = record.get("s3", {}).get("object", {}).get("key", "unknown-key")
+        event_name = record.get("eventName", "unknown-event")
+        print(f"PROCESSED bucket={bucket} key={key} event={event_name}")
+
+    return {"statusCode": 200}
+```
+
+Use this exact code (or behaviorally identical code) as the function's
+handler. The validator does not inspect log content, but the optional
+self-check described later in this README does — if you write your own
+function logic instead of using this code, make sure it still prints a
+recognizable line so you can confirm invocation manually.
+
+---
+
+## Requirements
+
+Build the following infrastructure in your AWS account. All resource names
+must use the prefix `kata-204-`.
+
+You are given a spec, not a tutorial. Use the AWS Console, CLI, IaC, or any
+tools you choose to meet these requirements. Consult the AWS documentation,
+use AI assistants, or search the web — whatever you would use on the job.
+
+---
+
+### Requirement 1 — S3 Bucket
+
+Create an S3 bucket with a name that **starts with** the prefix
+`kata-204-bucket-`.
+
+> S3 bucket names must be globally unique across all AWS accounts. You
+> cannot use the prefix alone as the full bucket name — append something
+> unique to it, such as your AWS account ID or a random suffix, e.g.
+> `kata-204-bucket-123456789012`.
+
+- **Name:** must start with `kata-204-bucket-`
+- The validator discovers your bucket by searching for this prefix, so any
+  suffix you choose is fine as long as the prefix matches exactly.
+
+---
+
+### Requirement 2 — Lambda Function
+
+Create a Lambda function with the following configuration:
+
+- **Name:** `kata-204-ProcessorFunction` (exact name required)
+- **Runtime:** Python 3.12
+- **Handler code:** the code provided above in
+  [Provided Lambda Function Code](#provided-lambda-function-code)
+- **Permission** the function must be able to write its own
+  invocation logs to CloudWatch Logs
+- **Timeout:** at least 10 seconds
+
+---
+
+### Requirement 3 — S3 Event Notification
+
+Configure an S3 event notification on your bucket so that **all object
+creation events** (`s3:ObjectCreated:*`) invoke `kata-204-ProcessorFunction`.
+
+- No prefix or suffix filter is required — the notification should apply to
+  the whole bucket.
+
+---
+
+### Requirement 4 — Permission to Invoke
+
+`kata-204-ProcessorFunction` must be invocable by your S3 bucket
+specifically — not by S3 buckets in general, and not by any other AWS
+service or account.
+
+- Your bucket must be able to invoke the function
+- Other buckets, services, or accounts must not gain this ability as a
+  side effect of however you grant it
+
+---
+
+### Optional — Verify It Yourself
+
+The validator confirms your trigger is wired correctly, but it does not
+upload a test object or check for an actual invocation. If you want to see
+the whole thing work end to end before moving on, you can check it
+yourself:
+
+```bash
+echo "hello kata-204" > /tmp/test-object.txt
+aws s3 cp /tmp/test-object.txt s3://<your-bucket-name>/manual-test.txt
+```
+
+Then check the function's log group (`/aws/lambda/kata-204-ProcessorFunction`)
+for a line containing `PROCESSED bucket=` and `key=manual-test.txt`. This
+step is optional and not scored.
+
+---
+
+## Running the Validator
+
+Once you have built the required infrastructure, open AWS CloudShell and
+upload or copy `validate.sh` to your CloudShell environment, then run:
+
+```bash
+sed -i 's/\r//' validate.sh
+chmod +x validate.sh
+./validate.sh
+```
+
+The validator checks your live AWS infrastructure and reports a score.
+A fully passing result looks like this:
+
+```
+==================================================
+ CloudKata Validator — kata-204
+ S3 + Lambda: Event Notifications & Triggers
+==================================================
+
+✅ PASS — Bucket with prefix 'kata-204-bucket-' exists
+✅ PASS — Lambda function 'kata-204-ProcessorFunction' exists
+✅ PASS — Lambda runtime is python3.12
+✅ PASS — S3 event notification configured for s3:ObjectCreated:*
+✅ PASS — Notification targets 'kata-204-ProcessorFunction'
+✅ PASS — Lambda resource policy allows s3.amazonaws.com to invoke the function
+✅ PASS — Resource policy is scoped to this bucket
+
+==================================================
+ Results: 7/7 checks passed (100%)
+==================================================
+
+ 🎉 Perfect score! All kata-204 requirements met.
+```
+
+---
+
+## Cleanup
+
+Always clean up your resources when you are finished. Follow these steps
+in order.
+
+### Step 1 — Delete CloudFormation stacks (if applicable)
+
+If you deployed `solution.yml`, delete that stack first via CloudFormation.
+
+```bash
+aws cloudformation delete-stack --stack-name kata-204-solution
+aws cloudformation wait stack-delete-complete --stack-name kata-204-solution
+```
+
+> ⚠️ **S3 buckets must be empty before they can be deleted.** If the stack
+> deletion fails with a `DELETE_FAILED` status on the bucket resource,
+> empty the bucket manually and re-run the delete:
+>
+> ```bash
+> aws s3 rm s3://<your-bucket-name> --recursive
+> aws cloudformation delete-stack --stack-name kata-204-solution
+> ```
+
+### Step 2 — Manual Cleanup
+
+If you created any resources manually via the console or via the CLI, it is
+your responsibility to delete them to avoid incurring ongoing costs.
+
+- Empty and delete the S3 bucket
+- Delete the Lambda function `kata-204-ProcessorFunction`
+- Delete the IAM role created for the function's execution role
+- Delete the CloudWatch Logs log group
+  `/aws/lambda/kata-204-ProcessorFunction`
+
+Read the instructions again and work backwards to ensure you have deleted
+all created resources.
+
+### Step 3 — Verify in the console
+
+Go to the S3 console and confirm the `kata-204-bucket-*` bucket no longer
+exists. Go to the Lambda console and confirm `kata-204-ProcessorFunction`
+no longer exists.
+
+> ⚠️ If you leave infrastructure running, costs will continue to accumulate
+> and are your responsibility.
+
+---
+
+## Hints & Solution
+
+Stuck? Refer to [HINTS.md](./HINTS.md) for progressive hints without full
+spoilers.
+
+The complete solution is available in [solution.yml](./solution.yml).
+Deploying `solution.yml` and re-running `validate.sh` should produce a
+score of 100%.

--- a/katas/kata-204-lambda-event-notification-and-triggers/solution.yml
+++ b/katas/kata-204-lambda-event-notification-and-triggers/solution.yml
@@ -1,0 +1,174 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  CloudKata kata-204 — S3 + Lambda: Event Notifications & Triggers.
+  Deploys an S3 bucket wired to invoke a Lambda function on every
+  ObjectCreated event, with the bucket-to-function permission scoped to
+  this specific bucket. Avoids the classic S3<->Lambda circular dependency
+  by giving the bucket an explicit, predictable name instead of letting
+  CloudFormation auto-generate one.
+
+# =============================================================================
+# Resources
+# =============================================================================
+
+Resources:
+
+  # ---------------------------------------------------------------------------
+  # CloudWatch Logs — explicit log group for the Lambda function
+  #
+  # Lambda creates this log group implicitly on first invocation if it does
+  # not already exist, but an implicitly-created log group lives outside the
+  # stack and is orphaned on stack deletion. Creating it explicitly here
+  # means it is torn down automatically when the stack is deleted, and its
+  # retention period is under our control rather than defaulting to "never
+  # expire".
+  # ---------------------------------------------------------------------------
+  ProcessorFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/kata-204-ProcessorFunction
+      RetentionInDays: 7
+
+  # ---------------------------------------------------------------------------
+  # IAM Role — Lambda execution role
+  #
+  # Grants only what Requirement 2 asks for: the ability to write its own
+  # invocation logs to CloudWatch Logs. The function reads S3 event data
+  # passed to it by the S3 service itself — it never calls an S3 API — so
+  # no S3 permissions belong on this role.
+  # ---------------------------------------------------------------------------
+  ProcessorFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: kata-204-ProcessorFunctionRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-204
+
+  # ---------------------------------------------------------------------------
+  # Lambda Function — kata-204-ProcessorFunction
+  #
+  # Code matches the handler provided in the README exactly. The function
+  # logs a "PROCESSED bucket=... key=... event=..." line for every S3 record
+  # it receives — this is the exact marker validate.sh searches for in
+  # CloudWatch Logs after uploading its test object.
+  # ---------------------------------------------------------------------------
+  ProcessorFunction:
+    Type: AWS::Lambda::Function
+    DependsOn: ProcessorFunctionLogGroup
+    Properties:
+      FunctionName: kata-204-ProcessorFunction
+      Description: "CloudKata kata-204 — logs details of every S3 object that triggers it"
+      Runtime: python3.12
+      Handler: index.handler
+      Role: !GetAtt ProcessorFunctionRole.Arn
+      Timeout: 10
+      Code:
+        ZipFile: |
+          import json
+
+          def handler(event, context):
+              print("kata-204 ProcessorFunction invoked")
+              print(json.dumps(event))
+
+              for record in event.get("Records", []):
+                  bucket = record.get("s3", {}).get("bucket", {}).get("name", "unknown-bucket")
+                  key = record.get("s3", {}).get("object", {}).get("key", "unknown-key")
+                  event_name = record.get("eventName", "unknown-event")
+                  print(f"PROCESSED bucket={bucket} key={key} event={event_name}")
+
+              return {"statusCode": 200}
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-204
+
+  # ---------------------------------------------------------------------------
+  # Lambda Permission — allows S3 to invoke ProcessorFunction
+  #
+  # SourceArn is built with !Sub against the bucket's own name string below
+  # rather than !GetAtt/!Ref on the Bucket resource. This is the key move
+  # that avoids the classic S3<->Lambda circular dependency: if SourceArn
+  # referenced the Bucket resource directly, CloudFormation would need the
+  # bucket to exist before creating this permission, while the bucket's own
+  # NotificationConfiguration (below) needs this permission to exist first
+  # — a cycle CloudFormation cannot resolve. Because the bucket has an
+  # explicit, predictable name, we can construct its ARN as a plain string
+  # and never create that reference cycle in the first place.
+  # ---------------------------------------------------------------------------
+  S3InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ProcessorFunction
+      Action: lambda:InvokeFunction
+      Principal: s3.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
+      SourceArn: !Sub "arn:aws:s3:::kata-204-bucket-${AWS::AccountId}"
+
+  # ---------------------------------------------------------------------------
+  # S3 Bucket — kata-204-bucket-<account-id>
+  #
+  # Uses an explicit BucketName (account ID suffix guarantees uniqueness)
+  # instead of letting CloudFormation auto-generate one. This is required
+  # for the SourceArn construction above to work without a circular
+  # dependency — see the comment on S3InvokePermission for the full
+  # explanation.
+  #
+  # DependsOn S3InvokePermission ensures the permission exists before S3
+  # validates the NotificationConfiguration; S3 checks that the target
+  # Lambda function's resource policy already grants it invoke permission
+  # at the time the notification configuration is applied, and will reject
+  # the configuration otherwise.
+  # ---------------------------------------------------------------------------
+  ProcessorBucket:
+    Type: AWS::S3::Bucket
+    DependsOn: S3InvokePermission
+    Properties:
+      BucketName: !Sub "kata-204-bucket-${AWS::AccountId}"
+      NotificationConfiguration:
+        LambdaConfigurations:
+          - Event: "s3:ObjectCreated:*"
+            Function: !GetAtt ProcessorFunction.Arn
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-204
+
+# =============================================================================
+# Outputs
+# =============================================================================
+
+Outputs:
+
+  BucketName:
+    Description: Name of the S3 bucket wired to trigger the Lambda function
+    Value: !Ref ProcessorBucket
+
+  FunctionName:
+    Description: Name of the Lambda function triggered by S3 uploads
+    Value: !Ref ProcessorFunction
+
+  FunctionArn:
+    Description: ARN of the Lambda function
+    Value: !GetAtt ProcessorFunction.Arn
+
+  LogGroupName:
+    Description: CloudWatch Logs group to inspect for invocation evidence
+    Value: !Ref ProcessorFunctionLogGroup
+
+  ValidatorInstructions:
+    Description: How to validate this kata
+    Value: "Run validate.sh in AWS CloudShell after deploying this stack"

--- a/katas/kata-204-lambda-event-notification-and-triggers/validate.sh
+++ b/katas/kata-204-lambda-event-notification-and-triggers/validate.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# =============================================================================
+# CloudKata — kata-204 Validator
+# kata:    kata-204
+# title:   S3 + Lambda: Event Notifications & Triggers
+# author:  Faisal Akhtar
+# github:  https://github.com/fakhtar
+# =============================================================================
+#
+# Run this script in AWS CloudShell after building your kata infrastructure.
+#
+# Usage:
+#   sed -i 's/\r//' validate.sh
+#   chmod +x validate.sh
+#   ./validate.sh
+#
+# =============================================================================
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+BUCKET_PREFIX="kata-204-bucket-"
+FUNCTION_NAME="kata-204-ProcessorFunction"
+EXPECTED_RUNTIME="python3.12"
+
+# ------------------------------------------------------------------------------
+# Helper functions
+# ------------------------------------------------------------------------------
+pass() {
+  echo "✅ PASS — $1"
+  PASS=$((PASS + 1))
+  TOTAL=$((TOTAL + 1))
+}
+
+fail() {
+  echo "❌ FAIL — $1: $2"
+  FAIL=$((FAIL + 1))
+  TOTAL=$((TOTAL + 1))
+}
+
+# ------------------------------------------------------------------------------
+# Header
+# ------------------------------------------------------------------------------
+echo ""
+echo "=================================================="
+echo " CloudKata Validator — kata-204"
+echo " S3 + Lambda: Event Notifications & Triggers"
+echo "=================================================="
+echo ""
+
+# ------------------------------------------------------------------------------
+# Check 1 — Bucket with prefix exists (hard gate for checks 3, 4, 6, 7)
+# ------------------------------------------------------------------------------
+echo "Checking for bucket with prefix '${BUCKET_PREFIX}'..."
+BUCKET_NAME=$(aws s3api list-buckets \
+  --query "Buckets[?starts_with(Name, '${BUCKET_PREFIX}')].Name | [0]" \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+if [ "$BUCKET_NAME" != "NOT_FOUND" ] && [ "$BUCKET_NAME" != "None" ] && [ -n "$BUCKET_NAME" ]; then
+  pass "Bucket with prefix '${BUCKET_PREFIX}' exists (${BUCKET_NAME})"
+else
+  fail "Bucket discovery" "No bucket found starting with '${BUCKET_PREFIX}' — ensure the bucket exists with this exact prefix"
+  echo ""
+  echo "  Cannot continue without a valid bucket. Please create the bucket and re-run."
+  echo ""
+  echo "=================================================="
+  echo " Results: 0/$((TOTAL)) checks passed (0%)"
+  echo "=================================================="
+  exit 1
+fi
+
+# ------------------------------------------------------------------------------
+# Check 2 — Lambda function exists with the correct runtime (hard gate for 4, 6, 7)
+# ------------------------------------------------------------------------------
+echo "Checking Lambda function '${FUNCTION_NAME}'..."
+FUNCTION_JSON=$(aws lambda get-function \
+  --function-name "$FUNCTION_NAME" \
+  --output json 2>/dev/null)
+
+if [ -z "$FUNCTION_JSON" ] || [ "$FUNCTION_JSON" = "null" ]; then
+  fail "Lambda function '${FUNCTION_NAME}'" "Function not found — ensure a function named exactly '${FUNCTION_NAME}' exists"
+  fail "Lambda runtime" "Could not check — function not found"
+else
+  pass "Lambda function '${FUNCTION_NAME}' exists"
+
+  RUNTIME=$(echo "$FUNCTION_JSON" | jq -r '.Configuration.Runtime // empty')
+
+  # ----------------------------------------------------------------------------
+  # Check 3 — Runtime is python3.12
+  # ----------------------------------------------------------------------------
+  if [ "$RUNTIME" = "$EXPECTED_RUNTIME" ]; then
+    pass "Lambda runtime is ${EXPECTED_RUNTIME}"
+  else
+    fail "Lambda runtime" "Found '${RUNTIME}' but expected '${EXPECTED_RUNTIME}'"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 4 — S3 event notification configured for s3:ObjectCreated:* targeting
+#           the function (hard gate informs but does not block checks 5+)
+# ------------------------------------------------------------------------------
+echo "Checking S3 event notification configuration on '${BUCKET_NAME}'..."
+NOTIFICATION_JSON=$(aws s3api get-bucket-notification-configuration \
+  --bucket "$BUCKET_NAME" \
+  --output json 2>/dev/null)
+
+LAMBDA_CONFIGS=$(echo "$NOTIFICATION_JSON" | jq -c '.LambdaFunctionConfigurations // []' 2>/dev/null)
+MATCHING_CONFIG=$(echo "$LAMBDA_CONFIGS" | jq -c --arg fn "$FUNCTION_NAME" \
+  '[.[] | select(.LambdaFunctionArn != null and (.LambdaFunctionArn | endswith($fn)))] | .[0]' 2>/dev/null)
+
+if [ "$MATCHING_CONFIG" != "null" ] && [ -n "$MATCHING_CONFIG" ] && [ "$MATCHING_CONFIG" != "[]" ]; then
+  EVENTS=$(echo "$MATCHING_CONFIG" | jq -r '.Events // [] | join(",")' 2>/dev/null)
+  HAS_OBJECT_CREATED=$(echo "$MATCHING_CONFIG" | jq -r \
+    '[.Events // [] | .[] | select(startswith("s3:ObjectCreated"))] | length' 2>/dev/null)
+
+  if [ "$HAS_OBJECT_CREATED" -ge 1 ] 2>/dev/null; then
+    pass "S3 event notification configured for s3:ObjectCreated events (${EVENTS})"
+  else
+    fail "S3 event notification" "Notification found targeting the function, but no s3:ObjectCreated event type configured (found: ${EVENTS:-none})"
+  fi
+
+  # ----------------------------------------------------------------------------
+  # Check 5 — Notification targets the correct function
+  # (folded into Check 4's matching logic — confirmed by MATCHING_CONFIG itself)
+  # ----------------------------------------------------------------------------
+  pass "Notification targets '${FUNCTION_NAME}'"
+else
+  fail "S3 event notification" "No LambdaFunctionConfigurations entry found targeting '${FUNCTION_NAME}' on bucket '${BUCKET_NAME}'"
+  fail "Notification target" "Cannot check — no matching notification configuration found"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 6 — Lambda resource policy allows s3.amazonaws.com to invoke the function
+# Check 7 — Resource policy is scoped to this specific bucket
+#
+# get-policy returns Policy as a JSON *string*, not a nested object — it must
+# be parsed with jq's fromjson before inspecting Principal/Resource/Condition.
+# ------------------------------------------------------------------------------
+echo "Checking Lambda resource-based policy..."
+POLICY_RAW=$(aws lambda get-policy \
+  --function-name "$FUNCTION_NAME" \
+  --query 'Policy' \
+  --output text 2>/dev/null)
+
+if [ -z "$POLICY_RAW" ] || [ "$POLICY_RAW" = "None" ]; then
+  fail "Lambda resource policy" "No resource-based policy found on '${FUNCTION_NAME}' — S3 has not been granted invoke permission"
+  fail "Resource policy bucket scope" "Cannot check — no resource policy found"
+else
+  POLICY_JSON=$(echo "$POLICY_RAW" | jq -c '.' 2>/dev/null)
+
+  S3_STATEMENT=$(echo "$POLICY_JSON" | jq -c \
+    '[.Statement[]? | select(.Principal.Service == "s3.amazonaws.com" and .Action == "lambda:InvokeFunction")] | .[0]' 2>/dev/null)
+
+  if [ "$S3_STATEMENT" != "null" ] && [ -n "$S3_STATEMENT" ]; then
+    pass "Lambda resource policy allows s3.amazonaws.com to invoke the function"
+
+    SOURCE_ARN=$(echo "$S3_STATEMENT" | jq -r \
+      '.Condition.ArnLike."AWS:SourceArn" // .Condition.ArnLike."aws:SourceArn" // empty' 2>/dev/null)
+    EXPECTED_BUCKET_ARN="arn:aws:s3:::${BUCKET_NAME}"
+
+    if [ "$SOURCE_ARN" = "$EXPECTED_BUCKET_ARN" ]; then
+      pass "Resource policy is scoped to bucket '${BUCKET_NAME}'"
+    elif [ -z "$SOURCE_ARN" ]; then
+      fail "Resource policy bucket scope" "Statement allows s3.amazonaws.com but has no SourceArn condition — this permits ANY bucket in ANY account to invoke the function"
+    else
+      fail "Resource policy bucket scope" "SourceArn is '${SOURCE_ARN}' but expected '${EXPECTED_BUCKET_ARN}'"
+    fi
+  else
+    fail "Lambda resource policy" "No statement found granting s3.amazonaws.com permission to call lambda:InvokeFunction"
+    fail "Resource policy bucket scope" "Cannot check — no matching s3.amazonaws.com statement found"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Summary
+# ------------------------------------------------------------------------------
+echo ""
+echo "=================================================="
+if [ "$TOTAL" -gt 0 ]; then
+  PERCENTAGE=$(( PASS * 100 / TOTAL ))
+else
+  PERCENTAGE=0
+fi
+echo " Results: $PASS/$TOTAL checks passed ($PERCENTAGE%)"
+echo "=================================================="
+echo ""
+
+if [ "$PERCENTAGE" -eq 100 ]; then
+  echo " 🎉 Perfect score! All kata-204 requirements met."
+  echo ""
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+  echo " Review the failed checks above, fix your infrastructure,"
+  echo " and re-run this validator."
+  echo ""
+  exit 1
+fi


### PR DESCRIPTION
Adds the fourth file set to the CloudKata catalog (kata-204), covering the foundational S3-to-Lambda event trigger pattern at the 200 level. Bots/intents (kata-100), SSM parameters (kata-109), and now S3 event notifications join the existing kata-108/110/203/207/200/300 set.

Spec-driven requirements document covering four scored requirements: bucket creation with a unique-suffix prefix (kata-204-bucket-), Lambda function deployment using README-provided code (not a coding kata), S3 event notification wiring, and a scoped resource-based permission.

Two editorial passes were needed to keep the spec honest to the project's "observable outcomes only" principle:

  - Requirement 4 originally specified the CloudFormation/IAM property names directly (Principal: s3.amazonaws.com, Action: lambda:InvokeFunction) — this was implementation syntax disguised as a requirement. Rewrote to state the outcome only ("must be invocable by your bucket specifically, not by buckets/services/ accounts in general") and moved the API shape to HINTS.md where it belongs.
  - Requirement 2 named the AWSLambdaBasicExecutionRole managed policy and explained why no S3 permissions were needed on the execution role — same problem, same fix. Now states only that the function must be able to write its own logs.

A fifth requirement (live invocation proof via an uploaded test object) was descoped entirely after live testing — see validate.sh section below — and demoted to an unscored "Verify It Yourself" section so learners who want end-to-end confidence still have the steps, without the validator depending on it.

Originally shipped with 9 checks including a live end-to-end test: upload a real object with a timestamp-based key, then poll filter-log-events for a matching "PROCESSED bucket=... key=..." line in CloudWatch Logs.

Live debugging session (CloudShell, real AWS account) surfaced a genuine async-delivery-lag failure: the function was invoked correctly for a given upload, confirmed via the CloudWatch console with the exact expected log line, but the invocation landed ~95 seconds after upload — comfortably past the original 30-second window (6 attempts x 5s). Root-caused from the user-supplied CloudWatch log export before any code changed, per the project's "root cause before fix" rule.

First fix: widened the poll window to 12 attempts x 10s (120s total) and reworded the failure message to report actual elapsed time rather than a vague "log delivery can lag a few seconds." Verified by building a local aws CLI shim that simulates delayed log delivery (returns no match until the 3rd polling attempt) to confirm the retry loop itself behaves correctly under realistic conditions, not just on an instant-match happy path.

Second iteration, per explicit instruction to drop the live-invocation check as unnecessary: removed Check 8 (test upload) and Check 9 (log polling) entirely. Validator now stops at 7 checks, all purely configuration-based:

  1. Bucket exists with the kata-204-bucket- prefix (hard gate)
  2. Lambda function exists (hard gate for 4, 6, 7)
  3. Runtime is python3.12
  4. S3 notification configured for an s3:ObjectCreated event
  5. Notification targets the correct function
  6. Resource policy grants s3.amazonaws.com invoke permission
  7. Resource policy SourceArn is scoped to this specific bucket (not a wildcard grant — a missing SourceArn condition fails this check even though it would technically allow invocation, since "any bucket can invoke this" is a meaningfully different and weaker guarantee than "this bucket can invoke this")

Removed now-dead POLL_ATTEMPTS/POLL_INTERVAL/LOG_GROUP constants and the associated stale "hard gate for checks 3,4,8,9" comments. Result: faster, fully deterministic validator runtime with no sleep-based flakiness, at the accepted cost of no longer proving the trigger fires in practice — a SourceArn typo'd to a well-formed but wrong bucket ARN, for instance, would now pass all 7 checks. Flagged this tradeoff explicitly rather than letting it pass silently.

Caught and fixed during pre-presentation verification (not live AWS, but jq fixture testing): `[.[] | select(...)] | [0]` does not index into the filtered array — `[0]` constructs a brand-new one-element array literal containing the integer zero. The correct form is `.[0]`. This bug appeared identically in two places (notification config matching and resource-policy statement matching) and would have silently broken Checks 4/5 and 6/7 against any real AWS account, despite passing `bash -n` and looking correct on visual inspection. Caught only by piping realistic fixture JSON through both versions and diffing the output — confirms jq logic needs execution-based verification, not just syntax checking, per the kata's mandatory pre-writing checklist.

Also removed a dead FUNCTION_ARN computation (two unused aws calls: sts get-caller-identity, configure get) left over from an earlier draft.

Verified end-to-end against a hand-built aws CLI mock exercising five scenarios: full pass, no bucket found (hard exit), wrong runtime + missing notification + wildcard-open resource policy + simultaneously, function not found entirely, and (pre-removal) delayed log delivery. Every failure path produces an accurate, specific message and a non-zero exit code; no scenario crashes on an unset variable.

Five resources: explicit AWS::Logs::LogGroup (so log retention and teardown are stack-managed instead of relying on Lambda's implicit-creation/orphan-on-delete behavior), IAM execution role scoped to AWSLambdaBasicExecutionRole only, the Lambda function with inline ZipFile code matching the README's provided handler verbatim, an AWS::Lambda::Permission, and the S3 bucket with its NotificationConfiguration.

Central design decision: avoids the well-known S3<->Lambda circular CloudFormation dependency (bucket needs the function's ARN for its NotificationConfiguration; the Lambda permission needs the bucket's ARN for SourceArn; if both references go through Ref/GetAtt on each other's resources, CloudFormation cannot resolve a creation order) by giving the bucket an explicit, predictable BucketName (kata-204-bucket-${AWS::AccountId}) and building the SourceArn in S3InvokePermission from the same string via !Sub rather than referencing the bucket resource at all. This is the "static name" variant of the standard workaround (the alternative being a custom- resource Lambda that calls PutBucketNotificationConfiguration after the fact, as used in kata-109's SecureString parameter handling) — chosen here because it requires no extra Lambda function, custom resource boilerplate, or additional IAM permissions, at the cost of a predictable rather than auto-generated bucket name (acceptable since the kata's spec already requires a predictable prefix).

Resource creation order, confirmed via manual topological sort (not just cfn-lint, which validates schema correctness but does not construct the full intrinsic-function dependency graph and would not have caught a real cycle if one had been introduced — confirmed by deliberately writing one and observing cfn-lint pass it with only an unrelated warning):

  1. ProcessorFunctionLogGroup, ProcessorFunctionRole (no dependencies)
  2. ProcessorFunction (depends on both, via DependsOn + GetAtt)
  3. S3InvokePermission (depends only on ProcessorFunction — SourceArn is a plain !Sub string, never a bucket reference)
  4. ProcessorBucket (depends on both S3InvokePermission via explicit DependsOn, and ProcessorFunction via GetAtt in NotificationConfiguration)

Verified clean against cfn-lint 1.51.5 with zero errors/warnings. Cross-checked the LambdaConfiguration schema (singular "Event" key, not "Events"; "Function" key for the ARN) against AWS CloudFormation reference docs and multiple independent real-world template examples, since both key-naming variants appeared in different doc snippets during research and needed disambiguating before writing the template. Confirmed generated resource names (RoleName, FunctionName, BucketName, LogGroupName) fit within IAM/Lambda/S3/CloudWatch Logs length and charset constraints.

Three-level progressive hints per requirement, matching the kata-100/ kata-109 format. Hint 3 of Requirement 4 carries the full circular- dependency explanation and workaround in detail, since the README deliberately withholds this as implementation detail — this is the one file in the kata meant to contain it.

Every CLI command and AWS-behavior claim was cross-verified against documentation rather than written from memory: the create-bucket region/LocationConstraint exception for us-east-1, the IAM role propagation race condition that can cause "role cannot be assumed by Lambda" errors on rapid-fire CLI calls (confirmed as a real, well-documented issue across multiple independent sources — Terraform provider bug tracker, AWS re:Post, blog writeups — not an invented caveat), and the "PutBucketNotificationConfiguration replaces the entire configuration, it does not merge" warning (cross-referenced against the AWS CLI reference docs gathered earlier in this session).

Added a General Troubleshooting section covering the four failure modes that can break S3-to-Lambda wiring silently (missing/wrong-scoped resource policy, dropped or overwritten notification config, wrong bucket, and — for learners using the optional manual self-check only — async delivery lag that looks like a failure but isn't). Explicitly clarified in this section that the validator itself does not check invocation evidence, only the optional self-check does, to avoid contradicting the live debugging outcome that led to descoping Check 8/9 from validate.sh.