### PR TITLE
feat(kata-500): add Contact Center Platform kata — Connect, Lex V2, L…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -546,7 +546,7 @@ The following katas are planned for the CloudKata library. All are open for comm
 
 | ID | Title | Level | Type | Services | Status |
 |---|---|---|---|---|---|
-| [kata-300](./katas/kata-300-serverless-api/) | Serverless API — Lambda, API Gateway & DynamoDB | 300 | Breadth | Lambda, API Gateway, DynamoDB | Open |
+| [kata-300](./katas/kata-300-serverless-api/) | Serverless API — Lambda, API Gateway & DynamoDB | 300 | Breadth | Lambda, API Gateway, DynamoDB | Published |
 | kata-301 | Amazon Connect Contact Flows — IVR Design & Lex Integration | 300 | Depth | Connect, Lex V2 | Open |
 | kata-302 | AI-Powered IVR — Connect, Lex V2 & Lambda Fulfillment | 300 | Breadth | Connect, Lex V2, Lambda | Open |
 
@@ -561,7 +561,7 @@ The following katas are planned for the CloudKata library. All are open for comm
 
 | ID | Title | Level | Type | Services | Status |
 |---|---|---|---|---|---|
-| kata-500 | Contact Center Platform — Connect, Lex V2, Lambda, DynamoDB & CloudWatch | 500 | Breadth | Connect, Lex V2, Lambda, DynamoDB, CloudWatch | Open |
+|  [kata-500](./katas/kata-500-contact-center-platform/) | Contact Center Platform — Connect, Lex V2, Lambda, DynamoDB & CloudWatch | 500 | Breadth | Connect, Lex V2, Lambda, DynamoDB, CloudWatch | Published |
 
 **Status key:**
 - **Open** — available for community contribution, open an issue to claim

--- a/katas/kata-500-contact-center-platform/HINTS.md
+++ b/katas/kata-500-contact-center-platform/HINTS.md
@@ -1,0 +1,455 @@
+# kata-500 Hints — Contact Center Platform
+
+> ⚠️ **Spoiler warning.** Each hint section reveals progressively more detail.
+> Try to solve each requirement on your own before opening a hint. The learning
+> is in the struggle.
+
+---
+
+## How to use these hints
+
+Hints are organised by requirement number matching the README. Each requirement
+has up to three levels:
+
+- **Hint 1** — a nudge in the right direction
+- **Hint 2** — more specific guidance
+- **Hint 3** — the exact approach (near-solution level)
+
+---
+
+## Requirement 1 — Amazon Connect Instance
+
+<details>
+<summary>Hint 1 — Where to start</summary>
+
+Amazon Connect instance creation is available in the AWS Console under the
+Amazon Connect service, or via the AWS CLI. Not all AWS regions support
+Connect — `us-east-1` is the safest choice. If you have never created a
+Connect instance in this account, you may need to request a service quota
+increase before proceeding.
+
+</details>
+
+<details>
+<summary>Hint 2 — Identity management and telephony</summary>
+
+When creating the instance, you will be asked how users will be managed.
+Choose the option that stores and manages users within Connect itself, rather
+than federating to an external directory. Inbound and outbound calling are
+configured in the telephony settings of the instance — both must be enabled.
+
+</details>
+
+<details>
+<summary>Hint 3 — Contact flow logs and CloudFormation</summary>
+
+Contact flow log emission is a per-instance attribute, not a contact flow
+setting. In the console it appears under the instance settings in the Flows
+section. In CloudFormation, the `AWS::Connect::Instance` resource takes an
+`Attributes` block — the relevant property is `ContactflowLogs` (note the
+lowercase 'f'). Set it to `true`.
+
+One important caveat: **Amazon Connect instances cannot be deleted by
+CloudFormation.** If you deploy via a stack, you must manually delete the
+instance after the stack is torn down. The stack deletion will succeed, but
+the instance will remain until you remove it explicitly.
+
+</details>
+
+---
+
+## Requirement 2 — Lex V2 IVR Bot
+
+<details>
+<summary>Hint 1 — Bot structure</summary>
+
+Amazon Lex V2 is structured differently from V1. The bot itself is a
+container — intents, slots, and slot types all live inside a bot locale.
+Create the bot first, then navigate into its English (US) locale to add
+intents. The bot will not reach `Built` status until you explicitly trigger
+a build of the locale after configuring your intents.
+
+</details>
+
+<details>
+<summary>Hint 2 — The OrderId slot and the alias</summary>
+
+The `OrderId` slot must be marked as required on the `CheckOrderStatus`
+intent. This means configuring a prompt that the bot will use to elicit the
+value from the caller if they did not provide it upfront. For the slot type,
+use the built-in `AMAZON.AlphaNumeric` type — it handles mixed
+letter-and-digit inputs without needing a custom slot type.
+
+For the alias, creating it is not enough — you must also explicitly enable
+the `en_US` locale on the alias itself. This is a separate step from
+creating the alias and is easy to miss. Without it, the alias cannot be
+invoked for English (US) calls.
+
+</details>
+
+<details>
+<summary>Hint 3 — Lambda code hook on the alias</summary>
+
+The Lambda code hook that connects Lex to your fulfilment function is
+configured on the **alias**, not on the bot or the intent. In the console,
+navigate to the alias settings and look for the language-specific settings
+for English (US) — the Lambda function hook is configured there.
+
+In CloudFormation, this is the `BotAliasLocaleSettings` property of
+`AWS::Lex::BotAlias`. The structure is:
+
+```
+BotAliasLocaleSettings:
+  - LocaleId: en_US
+    BotAliasLocaleSetting:
+      Enabled: true
+      CodeHookSpecification:
+        LambdaCodeHook:
+          LambdaArn: <function ARN>
+          CodeHookInterfaceVersion: "1.0"
+```
+
+Note that `CodeHookInterfaceVersion` must be the string `"1.0"` — other
+values such as `"1"` will fail validation.
+
+Also note: `AWS::Lex::BotAlias` cannot point directly to the `DRAFT`
+version. You must first publish a `AWS::Lex::BotVersion` from `DRAFT`, then
+point the alias at the published version number.
+
+</details>
+
+---
+
+## Requirement 3 — Lambda Fulfilment Function
+
+<details>
+<summary>Hint 1 — Lex V2 invocation contract</summary>
+
+When Lex V2 invokes a Lambda function, it sends a structured event containing
+the session state, the recognised intent, and any slot values. The function
+must return a response in the Lex V2 fulfilment format — it is not the same
+format as Lex V1. The response must include a `sessionState` object with a
+`dialogAction` of type `Close` and an `intent` with state `Fulfilled`.
+
+</details>
+
+<details>
+<summary>Hint 2 — Extracting intent from the event and writing to DynamoDB</summary>
+
+The intent name is nested inside the event at
+`event['sessionState']['intent']['name']`. The caller session identifier is
+at `event['sessionId']`. Use these as the values for the `intentName` and
+`callerId` attributes respectively. For the timestamp, generate it inside the
+function at invocation time rather than relying on an event field.
+
+The function needs `dynamodb:PutItem` permission on
+`kata-500-CallerDataTable` in its execution role. The table name should be
+passed in via an environment variable rather than hardcoded.
+
+</details>
+
+<details>
+<summary>Hint 3 — Lex invocation permission</summary>
+
+Granting Lex permission to invoke the function requires a Lambda
+resource-based policy — an IAM execution role alone is not sufficient. In
+CloudFormation, use `AWS::Lambda::Permission` with `Principal:
+lexv2.amazonaws.com`. Scope it to your account with `SourceAccount` and to
+the specific bot alias ARN with `SourceArn`. Without this permission, Lex
+will receive an access denied error when attempting to invoke the function,
+even if everything else is correctly configured.
+
+</details>
+
+---
+
+## Requirement 4 — DynamoDB Table
+
+<details>
+<summary>Hint 1 — Key design</summary>
+
+The table stores one record per fulfilment invocation. Each record has a
+caller session identifier and a timestamp. Think about how you would query
+records — all invocations for a given caller, ordered by time. That access
+pattern should guide your choice of partition key and sort key.
+
+</details>
+
+<details>
+<summary>Hint 2 — Key schema</summary>
+
+Use `callerId` as the partition key (String) and `timestamp` as the sort key
+(String). This matches the record structure written by the Lambda function
+and allows efficient retrieval of all invocations for a given caller session.
+
+</details>
+
+<details>
+<summary>Hint 3 — Capacity and CloudFormation</summary>
+
+Use on-demand capacity (`PAY_PER_REQUEST` billing mode in CloudFormation) —
+there is no need to provision throughput for a kata workload. In
+`AWS::DynamoDB::Table`, set `BillingMode: PAY_PER_REQUEST` and define both
+keys in `AttributeDefinitions` and `KeySchema`. Only attributes used as keys
+need to appear in `AttributeDefinitions` — do not list `intentName`, `status`,
+or `timestamp` there unless they are index keys.
+
+</details>
+
+---
+
+## Requirement 5 — Contact Flow
+
+<details>
+<summary>Hint 1 — Association before flow creation</summary>
+
+Before you can reference a Lex V2 bot inside a contact flow, the bot must be
+associated with the Connect instance. This is a separate step from creating
+the bot. In the console it is done under the Connect instance settings →
+Amazon Lex. Via CloudFormation, use `AWS::Connect::IntegrationAssociation`
+with `IntegrationType: LEX_BOT` and `IntegrationArn` set to the bot alias
+ARN — not the bot ARN.
+
+</details>
+
+<details>
+<summary>Hint 2 — Contact flow content</summary>
+
+A contact flow is defined as a JSON document in the Connect flow language.
+The minimal structure for this kata is: play a greeting prompt, invoke the
+Lex bot to collect caller intent, then disconnect. The action type for
+invoking a Lex V2 bot is `ConnectParticipantWithLexBot`. It requires the
+alias ARN under `Parameters.LexV2Bot.AliasArn` and also requires at least
+one of `Text`, `SSML`, `PromptId`, or `Media` to be set — Connect will
+reject the flow at creation time if no prompt is provided on the bot
+invocation action.
+
+</details>
+
+<details>
+<summary>Hint 3 — Flow language structure and CloudFormation</summary>
+
+The Connect flow language JSON must follow this structure:
+
+```json
+{
+  "Version": "2019-10-30",
+  "StartAction": "<identifier of first action>",
+  "Actions": [
+    {
+      "Identifier": "<uuid-format string>",
+      "Type": "MessageParticipant",
+      "Parameters": { "Text": "Welcome message here." },
+      "Transitions": {
+        "NextAction": "<next identifier>",
+        "Errors": [{ "NextAction": "<fallback>", "ErrorType": "NoMatchingError" }],
+        "Conditions": []
+      }
+    },
+    {
+      "Identifier": "<uuid-format string>",
+      "Type": "ConnectParticipantWithLexBot",
+      "Parameters": {
+        "Text": "How can I help you today?",
+        "LexV2Bot": { "AliasArn": "<alias ARN>" }
+      },
+      "Transitions": {
+        "NextAction": "<disconnect identifier>",
+        "Errors": [
+          { "NextAction": "<disconnect>", "ErrorType": "NoMatchingError" },
+          { "NextAction": "<disconnect>", "ErrorType": "NoMatchingCondition" },
+          { "NextAction": "<disconnect>", "ErrorType": "InputTimeLimitExceeded" }
+        ],
+        "Conditions": []
+      }
+    },
+    {
+      "Identifier": "<uuid-format string>",
+      "Type": "DisconnectParticipant",
+      "Parameters": {},
+      "Transitions": {}
+    }
+  ]
+}
+```
+
+In CloudFormation, pass this as the `Content` property of
+`AWS::Connect::ContactFlow` using `Fn::Sub` to inject the bot alias ARN
+dynamically.
+
+</details>
+
+---
+
+## Requirement 6 — CloudWatch Log Group
+
+<details>
+<summary>Hint 1 — Log group naming</summary>
+
+Amazon Connect automatically emits contact flow logs to a log group named
+`/aws/connect/<instance-alias>` when flow logging is enabled on the instance.
+However, the validator checks for a log group named exactly
+`kata-500-ContactFlowLogs` — this is the canonical observability resource for
+this kata. Create it explicitly with the correct name and retention period.
+
+</details>
+
+<details>
+<summary>Hint 2 — Retention</summary>
+
+CloudWatch log groups have no retention set by default — logs are kept
+indefinitely. Set the retention period to 30 days. In the console this is
+under the log group settings → Edit retention. Via CLI:
+
+```bash
+aws logs put-retention-policy \
+  --log-group-name kata-500-ContactFlowLogs \
+  --retention-in-days 30
+```
+
+</details>
+
+<details>
+<summary>Hint 3 — CloudFormation</summary>
+
+Use `AWS::Logs::LogGroup` with `LogGroupName: kata-500-ContactFlowLogs` and
+`RetentionInDays: 30`. Create it explicitly — do not rely on auto-creation
+from Connect or Lambda, which would produce a log group with a different name
+and no retention policy set.
+
+</details>
+
+---
+
+## Requirement 7 — CloudWatch Alarm
+
+<details>
+<summary>Hint 1 — What to monitor</summary>
+
+Lambda publishes an `Errors` metric to the `AWS/Lambda` namespace
+automatically — no custom instrumentation is needed. The metric counts the
+number of invocations that resulted in an error (exceptions, timeouts, or
+out-of-memory failures). Filter the metric to your specific function using
+the `FunctionName` dimension.
+
+</details>
+
+<details>
+<summary>Hint 2 — Threshold and missing data</summary>
+
+The alarm must activate on the first error — set the threshold to 1 with a
+`GreaterThanOrEqualToThreshold` comparison. A function that has never been
+invoked will have no data points for the `Errors` metric. If missing data
+is treated as breaching, the alarm will immediately enter `ALARM` state on
+a freshly deployed function with no invocations. Set missing data treatment
+to `notBreaching` so the alarm stays in `OK` state when the function is idle.
+
+</details>
+
+<details>
+<summary>Hint 3 — CloudFormation</summary>
+
+In `AWS::CloudWatch::Alarm`, the key properties are:
+
+- `Namespace: AWS/Lambda`
+- `MetricName: Errors`
+- `Dimensions` — one dimension with `Name: FunctionName` and `Value:
+  kata-500-FulfillmentFunction`
+- `Statistic: Sum`
+- `Period: 60`
+- `EvaluationPeriods: 1`
+- `Threshold: 1`
+- `ComparisonOperator: GreaterThanOrEqualToThreshold`
+- `TreatMissingData: notBreaching`
+
+</details>
+
+---
+
+## Requirement 8 — End-to-End Integration
+
+<details>
+<summary>Hint 1 — The dependency order matters</summary>
+
+The five services have strict dependency ordering. You cannot create a
+contact flow that references a Lex bot until the bot is associated with the
+Connect instance. You cannot associate the bot until both the instance and
+the bot alias exist. Build in this order: IAM roles → DynamoDB → Lambda →
+Lex bot → Lex alias → Connect instance → bot association → contact flow →
+CloudWatch resources.
+
+</details>
+
+<details>
+<summary>Hint 2 — The two most commonly missed wiring steps</summary>
+
+Two integration steps are easy to overlook:
+
+1. **Lex bot association** — The bot must be associated with the Connect
+   instance via the Connect console (Instance settings → Amazon Lex → Add
+   bot) or via `AWS::Connect::IntegrationAssociation`. Simply creating the
+   bot is not enough — Connect has no awareness of it until it is explicitly
+   associated.
+
+2. **Lambda code hook on the alias** — The Lambda function must be
+   registered as the code hook on the `kata-500-ProdAlias` alias, not on the
+   bot itself. If you configure it on the bot's locale settings instead of
+   the alias, the validator will not find it.
+
+</details>
+
+<details>
+<summary>Hint 3 — Verifying the wiring via CLI</summary>
+
+Use these commands to verify each integration point independently before
+running the validator:
+
+```bash
+# Confirm the Lex bot is associated with the Connect instance
+INSTANCE_ID=$(aws connect list-instances \
+  --query "InstanceSummaryList[?InstanceAlias=='kata-500-instance'].Id | [0]" \
+  --output text)
+aws connect list-bots \
+  --instance-id "$INSTANCE_ID" \
+  --lex-version V2 \
+  --query "LexBots[].LexV2Bot.AliasArn" \
+  --output json
+
+# Confirm the Lambda hook is on the alias
+BOT_ID=$(aws lexv2-models list-bots \
+  --filters name=BotName,values=kata-500-IVRBot,operator=EQ \
+  --query 'botSummaries[0].botId' --output text)
+ALIAS_ID=$(aws lexv2-models list-bot-aliases \
+  --bot-id "$BOT_ID" \
+  --query "botAliasSummaries[?botAliasName=='kata-500-ProdAlias'].botAliasId | [0]" \
+  --output text)
+aws lexv2-models describe-bot-alias \
+  --bot-id "$BOT_ID" \
+  --bot-alias-id "$ALIAS_ID" \
+  --query "botAliasLocaleSettings.en_US.codeHookSpecification.lambdaCodeHook.lambdaArn" \
+  --output text
+```
+
+</details>
+
+---
+
+## Still stuck?
+
+The complete working solution is in [solution.yml](./solution.yml).
+
+Deploy it with:
+
+```bash
+aws cloudformation deploy \
+  --template-file solution.yml \
+  --stack-name kata-500-solution \
+  --capabilities CAPABILITY_IAM
+```
+
+Then re-run `validate.sh`. A correctly deployed solution should score 13/13.
+Study the solution to understand what you missed, then tear it down and try
+again from scratch.
+
+> ⚠️ Remember: the Connect instance must be deleted manually after the stack
+> is removed. CloudFormation cannot delete Connect instances.

--- a/katas/kata-500-contact-center-platform/README.md
+++ b/katas/kata-500-contact-center-platform/README.md
@@ -1,0 +1,299 @@
+---
+id: kata-500
+title: "Contact Center Platform — Connect, Lex V2, Lambda, DynamoDB & CloudWatch"
+level: 500
+type: breadth
+services:
+  - connect
+  - lex-v2
+  - lambda
+  - dynamodb
+  - cloudwatch
+tags:
+  - connect
+  - lex-v2
+  - lambda
+  - dynamodb
+  - cloudwatch
+  - conversational-ai
+  - serverless
+  - contact-center
+  - breadth
+  - expert
+estimated_time: 4 hours
+estimated_cost: "$1.00 - $5.00"
+author: Faisal Akhtar
+github: https://github.com/fakhtar
+---
+
+# kata-500 — Contact Center Platform: Connect, Lex V2, Lambda, DynamoDB & CloudWatch
+
+## Overview
+
+In this kata you will build a production-grade contact center platform by
+integrating five AWS services end-to-end. Amazon Connect handles telephony
+and contact routing. A Lex V2 bot serves as the conversational IVR, parsing
+caller intent. A Lambda function fulfils those intents, reading from and
+writing to a DynamoDB table that persists caller interaction records. CloudWatch
+provides the operational layer: an alarm monitors Lambda error rate and a
+dedicated log group receives contact flow logs from Connect.
+
+The validator checks every layer of the stack — that each service is correctly
+configured in isolation, that the integration wiring is in place, and that the
+observability layer is active. A score of 100% means the platform is fully
+operational.
+
+---
+
+## Prerequisites
+
+- An active AWS account
+- Access to AWS CloudShell
+- IAM permissions to create and manage Amazon Connect, Lex V2, Lambda,
+  DynamoDB, CloudWatch, and IAM resources
+- Familiarity with the AWS Console and CLI at an intermediate-to-advanced level
+- Amazon Connect is available in select regions — confirm your target region
+  supports all five services in this kata before starting. If you have never
+  used Connect in this account, verify your service quota for Connect instances.
+
+> ℹ️ **Recommended region:** `us-east-1` supports all five services and has
+> the broadest Connect feature availability.
+
+---
+
+## Cost & Time
+
+| | |
+|---|---|
+| ⏱ Estimated Time | ~4 hours |
+| 💰 Estimated Cost | ~$1.00 – $5.00 |
+
+> ⚠️ **Cost Warning:** This kata involves **five billable services running
+> concurrently.** These are estimates only. Actual costs depend on your AWS
+> region, account tier, usage volume, and how quickly you complete and clean
+> up the kata. Amazon Connect charges per minute of active contact flow
+> execution. Lambda charges per invocation and duration. DynamoDB charges for
+> reads, writes, and storage. Lex V2 charges per request. CloudWatch charges
+> for log ingestion and alarm evaluations. If you leave infrastructure running
+> beyond the kata session, costs will continue to accumulate. **All charges
+> are your responsibility.** Always run the cleanup instructions when finished.
+
+---
+
+## Requirements
+
+Build the following infrastructure in your AWS account. All resource names
+must follow the naming convention: `kata-500-ResourceName`
+
+You are given a spec, not a tutorial. Use the AWS Console, CLI, IaC, or any
+tools you choose to meet these requirements. Consult the AWS documentation,
+use AI assistants, or search the web — whatever you would use on the job.
+
+---
+
+### Requirement 1 — Amazon Connect Instance
+
+Create an Amazon Connect instance named `kata-500-instance`. Users must be
+managed directly by Amazon Connect. The instance must be able to receive and
+place calls. Contact flow log emission must be enabled. The instance must
+reach `ACTIVE` status.
+
+---
+
+### Requirement 2 — Lex V2 IVR Bot
+
+Create an Amazon Lex V2 bot named `kata-500-IVRBot`. The bot must support
+English (US), have a service role that permits Lex to call AWS services on
+its behalf, and time out idle sessions after a reasonable period. The bot
+locale must be built and reach `Built` status.
+
+The bot must contain the following intents in its English (US) locale:
+
+**Intent: `CheckOrderStatus`**
+- At least 5 distinct sample utterances expressing a desire to check an order
+  status
+- A slot named `OrderId` that captures an alphanumeric order identifier. The
+  slot must be required — the bot must elicit it from the caller if not
+  provided
+- A closing response confirming the intent was recognised
+
+**Intent: `CancelOrder`**
+- At least 5 distinct sample utterances expressing a desire to cancel an order
+- A closing response confirming the intent was recognised
+
+**Bot alias:** Create a bot alias named `kata-500-ProdAlias`. The alias must
+support English (US) and be configured with a Lambda code hook pointing to
+`kata-500-FulfillmentFunction` (see Requirement 3).
+
+---
+
+### Requirement 3 — Lambda Fulfilment Function
+
+Create a Lambda function named `kata-500-FulfillmentFunction`. The function
+must be configured with a timeout sufficient to complete a DynamoDB write and
+return a valid response to Lex. The function's execution role must grant it
+the permissions necessary to write records to `kata-500-CallerDataTable` and
+emit logs. Amazon Lex must be permitted to invoke the function.
+
+When invoked by Lex V2, the function must write a record to
+`kata-500-CallerDataTable`. Each record must identify the caller session, the
+recognised intent, the time of invocation, and carry a fulfilment status. At
+minimum the record must contain:
+
+- `callerId` — a non-empty string identifying the caller session
+- `intentName` — the name of the recognised intent from the Lex event
+- `timestamp` — the time of invocation
+- `status` — indicating the invocation was fulfilled
+
+---
+
+### Requirement 4 — DynamoDB Table
+
+Create a DynamoDB table named `kata-500-CallerDataTable` to store caller
+interaction records. The table must reach `ACTIVE` status.
+
+---
+
+### Requirement 5 — Contact Flow
+
+Create a contact flow named `kata-500-ContactFlow` inside `kata-500-instance`.
+The flow must invoke `kata-500-IVRBot` to handle caller input.
+
+---
+
+### Requirement 6 — CloudWatch Log Group
+
+Create a CloudWatch log group named `kata-500-ContactFlowLogs` with a
+retention period of 30 days.
+
+---
+
+### Requirement 7 — CloudWatch Alarm
+
+Create a CloudWatch alarm named `kata-500-LambdaErrorAlarm` that monitors
+`kata-500-FulfillmentFunction` for invocation errors. The alarm must activate
+on the first error detected. It must not enter an alarm state when the
+function has not been invoked. The alarm must be evaluable.
+
+---
+
+### Requirement 8 — End-to-End Integration
+
+All five services must be wired together as a cohesive platform:
+
+- `kata-500-IVRBot` must be associated with `kata-500-instance`
+- `kata-500-FulfillmentFunction` must be the Lambda code hook on
+  `kata-500-ProdAlias`
+- The execution role of `kata-500-FulfillmentFunction` must grant it access
+  to `kata-500-CallerDataTable`
+- `kata-500-ContactFlow` must exist within `kata-500-instance`
+
+---
+
+## Running the Validator
+
+Once you have built the required infrastructure, open AWS CloudShell and
+upload or copy `validate.sh` to your CloudShell environment, then run:
+
+```bash
+sed -i 's/\r//' validate.sh
+chmod +x validate.sh
+./validate.sh
+```
+
+The validator checks your live AWS infrastructure and reports a score.
+A fully passing result looks like this:
+
+```
+==================================================
+ CloudKata Validator — kata-500
+ Contact Center Platform
+==================================================
+
+✅ PASS — Connect instance 'kata-500-instance' is ACTIVE
+✅ PASS — Lex V2 bot 'kata-500-IVRBot' exists and locale is Built
+✅ PASS — Bot alias 'kata-500-ProdAlias' exists with en_US enabled
+✅ PASS — Lambda function 'kata-500-FulfillmentFunction' exists and is configured correctly
+✅ PASS — DynamoDB table 'kata-500-CallerDataTable' is ACTIVE
+✅ PASS — Contact flow 'kata-500-ContactFlow' exists in the Connect instance
+✅ PASS — CloudWatch log group 'kata-500-ContactFlowLogs' exists with 30-day retention
+✅ PASS — CloudWatch alarm 'kata-500-LambdaErrorAlarm' is correctly configured
+✅ PASS — Integration: Lex bot is associated with Connect instance
+✅ PASS — Integration: Lambda hook is configured on 'kata-500-ProdAlias'
+✅ PASS — Integration: Lambda execution role has DynamoDB access
+
+==================================================
+ Results: 11/11 checks passed (100%)
+==================================================
+
+ 🎉 Perfect score! All kata-500 requirements met.
+```
+
+---
+
+## Cleanup
+
+Always clean up your resources when you are finished. This kata spans five
+services — follow the steps in order to avoid orphaned dependencies that
+block deletion.
+
+### Step 1 — Delete CloudFormation stacks (if applicable)
+
+If you deployed `solution.yml`, delete that stack first.
+
+```bash
+aws cloudformation delete-stack --stack-name kata-500-solution
+aws cloudformation wait stack-delete-complete --stack-name kata-500-solution
+```
+
+> ⚠️ Amazon Connect instances cannot be deleted by CloudFormation. You must
+> delete the Connect instance manually after the stack is removed.
+
+### Step 2 — Delete the Amazon Connect instance manually
+
+Amazon Connect instances must be deleted via the console or CLI regardless of
+how they were created.
+
+Via CLI:
+
+```bash
+INSTANCE_ID=$(aws connect list-instances \
+  --query "InstanceSummaryList[?InstanceAlias=='kata-500-instance'].Id | [0]" \
+  --output text)
+aws connect delete-instance --instance-id "$INSTANCE_ID"
+```
+
+Via console: **Amazon Connect → Instances → kata-500-instance → Delete**
+
+### Step 3 — Manual cleanup of any remaining resources
+
+If you created resources manually outside of CloudFormation, delete them in
+reverse dependency order:
+
+1. Delete the CloudWatch alarm `kata-500-LambdaErrorAlarm`
+2. Delete the CloudWatch log group `kata-500-ContactFlowLogs`
+3. Delete the DynamoDB table `kata-500-CallerDataTable`
+4. Delete the Lambda function `kata-500-FulfillmentFunction` and its
+   execution role
+5. Delete the Lex V2 bot alias `kata-500-ProdAlias`, then the bot
+   `kata-500-IVRBot`
+6. Delete the Connect instance `kata-500-instance` (if not already done)
+
+### Step 4 — Verify in the console
+
+Confirm in each service console that no `kata-500-` resources remain.
+
+> ⚠️ If you leave infrastructure running, costs will continue to accumulate
+> and are your responsibility. Amazon Connect in particular continues to
+> accrue charges for an active instance even when no calls are in progress.
+
+---
+
+## Hints & Solution
+
+Stuck? Refer to [HINTS.md](./HINTS.md) for progressive hints without full
+spoilers.
+
+The complete solution is available in [solution.yml](./solution.yml).
+Deploying `solution.yml` and re-running `validate.sh` should produce a
+score of 100%.

--- a/katas/kata-500-contact-center-platform/solution.yml
+++ b/katas/kata-500-contact-center-platform/solution.yml
@@ -1,0 +1,489 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  CloudKata kata-500 — Contact Center Platform
+  Solution template. Deploys all infrastructure required to pass the
+  kata-500 validator at 100%.
+  NOTE: Amazon Connect instances cannot be deleted by CloudFormation.
+  After deleting this stack, you must manually delete the Connect instance
+  kata-500-instance via the console or CLI.
+
+# =============================================================================
+# Parameters
+# =============================================================================
+
+Parameters:
+  LexBotLocaleId:
+    Type: String
+    Default: en_US
+    Description: Locale ID for the Lex V2 bot
+
+# =============================================================================
+# Resources
+# =============================================================================
+
+Resources:
+
+  # ---------------------------------------------------------------------------
+  # IAM Role — Lambda Execution Role
+  # Grants the fulfilment function permission to write to DynamoDB and emit logs
+  # ---------------------------------------------------------------------------
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: kata-500-LambdaExecutionRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: kata-500-DynamoDBAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                  - dynamodb:GetItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:Query
+                Resource: !GetAtt CallerDataTable.Arn
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-500
+
+  # ---------------------------------------------------------------------------
+  # IAM Role — Lex V2 Service Role
+  # Allows Amazon Lex to call AWS services on behalf of the bot
+  # ---------------------------------------------------------------------------
+  LexServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: kata-500-LexServiceRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lexv2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonLexFullAccess
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-500
+
+  # ---------------------------------------------------------------------------
+  # DynamoDB Table — CallerDataTable
+  # Stores caller interaction records written by the Lambda function
+  # ---------------------------------------------------------------------------
+  CallerDataTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: kata-500-CallerDataTable
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: callerId
+          AttributeType: S
+        - AttributeName: timestamp
+          AttributeType: S
+      KeySchema:
+        - AttributeName: callerId
+          KeyType: HASH
+        - AttributeName: timestamp
+          KeyType: RANGE
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-500
+
+  # ---------------------------------------------------------------------------
+  # Lambda Function — FulfillmentFunction
+  # Invoked by Lex V2 to fulfil intents; writes interaction records to DynamoDB
+  # ---------------------------------------------------------------------------
+  FulfillmentFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: kata-500-FulfillmentFunction
+      Runtime: python3.12
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Timeout: 30
+      Environment:
+        Variables:
+          TABLE_NAME: kata-500-CallerDataTable
+      Code:
+        ZipFile: |
+          import boto3
+          import os
+          import datetime
+
+          dynamodb = boto3.resource('dynamodb')
+
+          def handler(event, context):
+              table_name = os.environ.get('TABLE_NAME', 'kata-500-CallerDataTable')
+              table = dynamodb.Table(table_name)
+
+              session_id = event.get('sessionId', 'unknown')
+              intent_name = event.get('sessionState', {}).get('intent', {}).get('name', 'unknown')
+              timestamp = datetime.datetime.utcnow().isoformat()
+
+              table.put_item(Item={
+                  'callerId': session_id,
+                  'timestamp': timestamp,
+                  'intentName': intent_name,
+                  'status': 'FULFILLED'
+              })
+
+              return {
+                  'sessionState': {
+                      'dialogAction': {
+                          'type': 'Close'
+                      },
+                      'intent': {
+                          'name': intent_name,
+                          'state': 'Fulfilled'
+                      }
+                  },
+                  'messages': [
+                      {
+                          'contentType': 'PlainText',
+                          'content': 'Thank you. Your request has been processed.'
+                      }
+                  ]
+              }
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-500
+
+  # ---------------------------------------------------------------------------
+  # Lambda Permission — Allow Lex V2 to invoke the function
+  # ---------------------------------------------------------------------------
+  LexInvokePermission:
+    Type: AWS::Lambda::Permission
+    DependsOn: IVRBotAlias
+    Properties:
+      FunctionName: !GetAtt FulfillmentFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: lexv2.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
+      SourceArn: !GetAtt IVRBotAlias.Arn
+
+  # ---------------------------------------------------------------------------
+  # Lex V2 Bot — IVRBot
+  # Handles CheckOrderStatus and CancelOrder intents
+  # ---------------------------------------------------------------------------
+  IVRBot:
+    Type: AWS::Lex::Bot
+    Properties:
+      Name: kata-500-IVRBot
+      Description: "CloudKata kata-500 IVR bot for food order management"
+      RoleArn: !GetAtt LexServiceRole.Arn
+      DataPrivacy:
+        ChildDirected: false
+      IdleSessionTTLInSeconds: 300
+      AutoBuildBotLocales: true
+      BotLocales:
+        - LocaleId: en_US
+          Description: "English (US) locale for kata-500-IVRBot"
+          NluConfidenceThreshold: 0.40
+          Intents:
+            # -----------------------------------------------------------------
+            # Intent 1 — CheckOrderStatus
+            # -----------------------------------------------------------------
+            - Name: CheckOrderStatus
+              Description: "Intent to check the status of an existing order"
+              SampleUtterances:
+                - Utterance: "What is the status of my order"
+                - Utterance: "Check my order status"
+                - Utterance: "Where is my order"
+                - Utterance: "Can you check on my order"
+                - Utterance: "I want to know the status of my order"
+                - Utterance: "Track my order"
+                - Utterance: "Check order {OrderId}"
+              Slots:
+                - Name: OrderId
+                  Description: "The alphanumeric order identifier"
+                  SlotTypeName: AMAZON.AlphaNumeric
+                  ValueElicitationSetting:
+                    SlotConstraint: Required
+                    PromptSpecification:
+                      MaxRetries: 3
+                      MessageGroupsList:
+                        - Message:
+                            PlainTextMessage:
+                              Value: "Please provide your order ID."
+              SlotPriorities:
+                - Priority: 1
+                  SlotName: OrderId
+              IntentClosingSetting:
+                ClosingResponse:
+                  MessageGroupsList:
+                    - Message:
+                        PlainTextMessage:
+                          Value: "I have received your request to check order {OrderId}."
+                IsActive: true
+
+            # -----------------------------------------------------------------
+            # Intent 2 — CancelOrder
+            # -----------------------------------------------------------------
+            - Name: CancelOrder
+              Description: "Intent to cancel an existing order"
+              SampleUtterances:
+                - Utterance: "Cancel my order"
+                - Utterance: "I want to cancel my order"
+                - Utterance: "Please cancel my order"
+                - Utterance: "I would like to cancel"
+                - Utterance: "Stop my order"
+                - Utterance: "I changed my mind about my order"
+                - Utterance: "Cancel that order"
+              IntentClosingSetting:
+                ClosingResponse:
+                  MessageGroupsList:
+                    - Message:
+                        PlainTextMessage:
+                          Value: "Your order has been cancelled."
+                IsActive: true
+
+            # -----------------------------------------------------------------
+            # FallbackIntent — Required by Lex V2
+            # -----------------------------------------------------------------
+            - Name: FallbackIntent
+              Description: "Default fallback when no intent matches"
+              ParentIntentSignature: AMAZON.FallbackIntent
+              IntentClosingSetting:
+                ClosingResponse:
+                  MessageGroupsList:
+                    - Message:
+                        PlainTextMessage:
+                          Value: "Sorry, I did not understand. You can check your order status or cancel an order."
+                IsActive: true
+
+  # ---------------------------------------------------------------------------
+  # Bot Version — publishes DRAFT as a numbered version for the alias
+  # ---------------------------------------------------------------------------
+  IVRBotVersion:
+    DependsOn: IVRBot
+    Type: AWS::Lex::BotVersion
+    Properties:
+      BotId: !Ref IVRBot
+      BotVersionLocaleSpecification:
+        - LocaleId: en_US
+          BotVersionLocaleDetails:
+            SourceBotVersion: DRAFT
+      Description: "kata-500 Version 1 - published from DRAFT"
+
+  # ---------------------------------------------------------------------------
+  # Bot Alias — kata-500-ProdAlias
+  # en_US locale enabled; Lambda code hook points to FulfillmentFunction
+  # ---------------------------------------------------------------------------
+  IVRBotAlias:
+    DependsOn: IVRBotVersion
+    Type: AWS::Lex::BotAlias
+    Properties:
+      BotId: !Ref IVRBot
+      BotAliasName: kata-500-ProdAlias
+      BotVersion: !GetAtt IVRBotVersion.BotVersion
+      Description: "CloudKata kata-500 production alias with Lambda code hook"
+      BotAliasLocaleSettings:
+        - LocaleId: en_US
+          BotAliasLocaleSetting:
+            Enabled: true
+            CodeHookSpecification:
+              LambdaCodeHook:
+                LambdaArn: !GetAtt FulfillmentFunction.Arn
+                CodeHookInterfaceVersion: "1.0"
+
+  # ---------------------------------------------------------------------------
+  # Amazon Connect Instance — kata-500-instance
+  # CONNECT_MANAGED identity; inbound and outbound calls; contact flow logs
+  # NOTE: CloudFormation cannot delete Connect instances. After stack deletion,
+  # manually delete kata-500-instance via the console or CLI.
+  # ---------------------------------------------------------------------------
+  ConnectInstance:
+    Type: AWS::Connect::Instance
+    Properties:
+      IdentityManagementType: CONNECT_MANAGED
+      InstanceAlias: kata-500-instance
+      Attributes:
+        InboundCalls: true
+        OutboundCalls: true
+        ContactflowLogs: true
+
+  # ---------------------------------------------------------------------------
+  # Integration Association — Associates IVRBot alias with Connect instance
+  # This is what aws connect list-bots returns under LexBots[].LexV2Bot.AliasArn
+  # ---------------------------------------------------------------------------
+  BotIntegration:
+    DependsOn:
+      - ConnectInstance
+      - IVRBotAlias
+    Type: AWS::Connect::IntegrationAssociation
+    Properties:
+      InstanceId: !GetAtt ConnectInstance.Arn
+      IntegrationType: LEX_BOT
+      IntegrationArn: !GetAtt IVRBotAlias.Arn
+
+  # ---------------------------------------------------------------------------
+  # Contact Flow — kata-500-ContactFlow
+  # Minimal CONTACT_FLOW type: greets the caller, invokes the Lex V2 bot,
+  # then disconnects. The Lex bot ARN is injected via Fn::Sub.
+  # ---------------------------------------------------------------------------
+  ContactFlow:
+    DependsOn: BotIntegration
+    Type: AWS::Connect::ContactFlow
+    Properties:
+      Name: kata-500-ContactFlow
+      Description: "CloudKata kata-500 contact flow - invokes IVRBot and disconnects"
+      InstanceArn: !GetAtt ConnectInstance.Arn
+      Type: CONTACT_FLOW
+      Content: !Sub
+        - |
+          {
+            "Version": "2019-10-30",
+            "StartAction": "11111111-1111-1111-1111-111111111111",
+            "Actions": [
+              {
+                "Identifier": "11111111-1111-1111-1111-111111111111",
+                "Type": "MessageParticipant",
+                "Parameters": {
+                  "Text": "Welcome to the kata-500 contact center."
+                },
+                "Transitions": {
+                  "NextAction": "22222222-2222-2222-2222-222222222222",
+                  "Errors": [
+                    { "NextAction": "33333333-3333-3333-3333-333333333333", "ErrorType": "NoMatchingError" }
+                  ],
+                  "Conditions": []
+                }
+              },
+              {
+                "Identifier": "22222222-2222-2222-2222-222222222222",
+                "Type": "ConnectParticipantWithLexBot",
+                "Parameters": {
+                  "Text": "How can I help you today?",
+                  "LexV2Bot": {
+                    "AliasArn": "${BotAliasArn}"
+                  }
+                },
+                "Transitions": {
+                  "NextAction": "33333333-3333-3333-3333-333333333333",
+                  "Errors": [
+                    { "NextAction": "33333333-3333-3333-3333-333333333333", "ErrorType": "NoMatchingError" },
+                    { "NextAction": "33333333-3333-3333-3333-333333333333", "ErrorType": "NoMatchingCondition" },
+                    { "NextAction": "33333333-3333-3333-3333-333333333333", "ErrorType": "InputTimeLimitExceeded" }
+                  ],
+                  "Conditions": []
+                }
+              },
+              {
+                "Identifier": "33333333-3333-3333-3333-333333333333",
+                "Type": "DisconnectParticipant",
+                "Parameters": {},
+                "Transitions": {}
+              }
+            ]
+          }
+        - BotAliasArn: !GetAtt IVRBotAlias.Arn
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-500
+
+  # ---------------------------------------------------------------------------
+  # CloudWatch Log Group — kata-500-ContactFlowLogs
+  # Receives contact flow logs; 30-day retention
+  # ---------------------------------------------------------------------------
+  ContactFlowLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: kata-500-ContactFlowLogs
+      RetentionInDays: 30
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-500
+
+  # ---------------------------------------------------------------------------
+  # CloudWatch Alarm — kata-500-LambdaErrorAlarm
+  # Triggers on the first invocation error from FulfillmentFunction
+  # ---------------------------------------------------------------------------
+  LambdaErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: kata-500-LambdaErrorAlarm
+      AlarmDescription: "Triggers when kata-500-FulfillmentFunction records an invocation error"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: kata-500-FulfillmentFunction
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+# =============================================================================
+# Outputs
+# =============================================================================
+
+Outputs:
+
+  ConnectInstanceId:
+    Description: The ID of the kata-500-instance Connect instance
+    Value: !GetAtt ConnectInstance.Id
+
+  ConnectInstanceArn:
+    Description: The ARN of the kata-500-instance Connect instance
+    Value: !GetAtt ConnectInstance.Arn
+
+  IVRBotId:
+    Description: The ID of the kata-500-IVRBot Lex V2 bot
+    Value: !Ref IVRBot
+
+  IVRBotAliasId:
+    Description: The ID of the kata-500-ProdAlias bot alias
+    Value: !Ref IVRBotAlias
+
+  IVRBotAliasArn:
+    Description: The ARN of the kata-500-ProdAlias bot alias
+    Value: !GetAtt IVRBotAlias.Arn
+
+  FulfillmentFunctionArn:
+    Description: The ARN of the kata-500-FulfillmentFunction Lambda function
+    Value: !GetAtt FulfillmentFunction.Arn
+
+  CallerDataTableArn:
+    Description: The ARN of the kata-500-CallerDataTable DynamoDB table
+    Value: !GetAtt CallerDataTable.Arn
+
+  ContactFlowArn:
+    Description: The ARN of the kata-500-ContactFlow contact flow
+    Value: !Ref ContactFlow
+
+  ContactFlowLogGroupArn:
+    Description: The ARN of the kata-500-ContactFlowLogs log group
+    Value: !GetAtt ContactFlowLogGroup.Arn
+
+  ValidatorInstructions:
+    Description: How to validate this kata
+    Value: "Run validate.sh in AWS CloudShell to check all kata-500 requirements"
+
+  CleanupWarning:
+    Description: Important cleanup note
+    Value: "IMPORTANT - Amazon Connect instances cannot be deleted by CloudFormation. After deleting this stack, manually delete kata-500-instance via the Connect console or CLI."

--- a/katas/kata-500-contact-center-platform/validate.sh
+++ b/katas/kata-500-contact-center-platform/validate.sh
@@ -1,0 +1,506 @@
+#!/bin/bash
+# =============================================================================
+# CloudKata — kata-500 Validator
+# kata:    kata-500
+# title:   Contact Center Platform
+# author:  Faisal Akhtar
+# github:  https://github.com/fakhtar
+# =============================================================================
+#
+# Run this script in AWS CloudShell after building your kata infrastructure.
+#
+# Usage:
+#   sed -i 's/\r//' validate.sh
+#   chmod +x validate.sh
+#   ./validate.sh
+#
+# =============================================================================
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+INSTANCE_ALIAS="kata-500-instance"
+BOT_NAME="kata-500-IVRBot"
+ALIAS_NAME="kata-500-ProdAlias"
+FUNCTION_NAME="kata-500-FulfillmentFunction"
+TABLE_NAME="kata-500-CallerDataTable"
+FLOW_NAME="kata-500-ContactFlow"
+LOG_GROUP_NAME="kata-500-ContactFlowLogs"
+ALARM_NAME="kata-500-LambdaErrorAlarm"
+LOCALE_ID="en_US"
+INTENT_1="CheckOrderStatus"
+INTENT_2="CancelOrder"
+SLOT_NAME="OrderId"
+MIN_UTTERANCES=5
+
+# ------------------------------------------------------------------------------
+# Helper functions
+# ------------------------------------------------------------------------------
+pass() {
+  echo "✅ PASS — $1"
+  PASS=$((PASS + 1))
+  TOTAL=$((TOTAL + 1))
+}
+
+fail() {
+  echo "❌ FAIL — $1: $2"
+  FAIL=$((FAIL + 1))
+  TOTAL=$((TOTAL + 1))
+}
+
+# ------------------------------------------------------------------------------
+# Header
+# ------------------------------------------------------------------------------
+echo ""
+echo "=================================================="
+echo " CloudKata Validator — kata-500"
+echo " Contact Center Platform"
+echo "=================================================="
+echo ""
+
+# ------------------------------------------------------------------------------
+# Check 1 — Connect instance exists and is ACTIVE
+# ------------------------------------------------------------------------------
+echo "Checking Connect instance..."
+INSTANCE_ID=$(aws connect list-instances \
+  --query "InstanceSummaryList[?InstanceAlias=='${INSTANCE_ALIAS}'].Id | [0]" \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+if [ "$INSTANCE_ID" = "NOT_FOUND" ] || [ "$INSTANCE_ID" = "None" ] || [ -z "$INSTANCE_ID" ]; then
+  fail "Connect instance '${INSTANCE_ALIAS}'" "Instance not found — ensure a Connect instance with alias '${INSTANCE_ALIAS}' exists"
+  echo ""
+  echo "  Cannot continue without a valid Connect instance. Please create it and re-run."
+  echo ""
+  echo "=================================================="
+  echo " Results: 0/$((TOTAL + 10)) checks passed (0%)"
+  echo "=================================================="
+  exit 1
+fi
+
+INSTANCE_STATUS=$(aws connect describe-instance \
+  --instance-id "$INSTANCE_ID" \
+  --query 'Instance.InstanceStatus' \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+if [ "$INSTANCE_STATUS" = "ACTIVE" ]; then
+  pass "Connect instance '${INSTANCE_ALIAS}' is ACTIVE (ID: ${INSTANCE_ID})"
+else
+  fail "Connect instance '${INSTANCE_ALIAS}'" "Expected status 'ACTIVE' but got '${INSTANCE_STATUS}'"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 2 — Connect instance attributes: inbound, outbound, contact flow logs
+# ------------------------------------------------------------------------------
+echo "Checking Connect instance attributes..."
+
+INBOUND=$(aws connect describe-instance \
+  --instance-id "$INSTANCE_ID" \
+  --query 'Instance.InboundCallsEnabled' \
+  --output text 2>/dev/null || echo "false")
+
+OUTBOUND=$(aws connect describe-instance \
+  --instance-id "$INSTANCE_ID" \
+  --query 'Instance.OutboundCallsEnabled' \
+  --output text 2>/dev/null || echo "false")
+
+# CONTACT_FLOW_LOGS is not reliably returned by list-instance-attributes.
+# describe-instance-attribute (singular) with --attribute-type is the correct API.
+FLOW_LOGS=$(aws connect describe-instance-attribute \
+  --instance-id "$INSTANCE_ID" \
+  --attribute-type CONTACTFLOW_LOGS \
+  --query 'Attribute.Value' \
+  --output text 2>/dev/null || echo "false")
+
+ATTR_FAILURES=0
+
+# AWS CLI --output text renders JSON booleans as "True"/"False" (capitalised).
+# Normalise to lowercase for a single comparison.
+INBOUND_LOWER=$(echo "$INBOUND" | tr '[:upper:]' '[:lower:]')
+OUTBOUND_LOWER=$(echo "$OUTBOUND" | tr '[:upper:]' '[:lower:]')
+FLOW_LOGS_LOWER=$(echo "$FLOW_LOGS" | tr '[:upper:]' '[:lower:]')
+
+if [ "$INBOUND_LOWER" != "true" ]; then
+  echo "   ✘ Inbound calls not enabled"
+  ATTR_FAILURES=$((ATTR_FAILURES + 1))
+fi
+if [ "$OUTBOUND_LOWER" != "true" ]; then
+  echo "   ✘ Outbound calls not enabled"
+  ATTR_FAILURES=$((ATTR_FAILURES + 1))
+fi
+if [ "$FLOW_LOGS_LOWER" != "true" ]; then
+  echo "   ✘ Contact flow logs not enabled"
+  ATTR_FAILURES=$((ATTR_FAILURES + 1))
+fi
+
+if [ "$ATTR_FAILURES" -eq 0 ]; then
+  pass "Connect instance has inbound, outbound, and contact flow logs enabled"
+else
+  fail "Connect instance attributes" "${ATTR_FAILURES} attribute(s) not correctly configured — check inbound/outbound calling and contact flow log settings"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 3 — Lex V2 bot exists, locale is Built
+# ------------------------------------------------------------------------------
+echo "Checking Lex V2 bot '${BOT_NAME}'..."
+BOT_ID=$(aws lexv2-models list-bots \
+  --filters name=BotName,values="${BOT_NAME}",operator=EQ \
+  --query 'botSummaries[0].botId' \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+if [ "$BOT_ID" = "NOT_FOUND" ] || [ "$BOT_ID" = "None" ] || [ -z "$BOT_ID" ]; then
+  fail "Lex V2 bot '${BOT_NAME}'" "Bot not found — ensure a Lex V2 bot named exactly '${BOT_NAME}' exists"
+else
+  LOCALE_STATUS=$(aws lexv2-models describe-bot-locale \
+    --bot-id "$BOT_ID" \
+    --bot-version "DRAFT" \
+    --locale-id "$LOCALE_ID" \
+    --query 'botLocaleStatus' \
+    --output text 2>/dev/null || echo "NOT_FOUND")
+
+  if [ "$LOCALE_STATUS" = "Built" ]; then
+    pass "Lex V2 bot '${BOT_NAME}' exists and locale is Built (ID: ${BOT_ID})"
+  else
+    fail "Lex V2 bot '${BOT_NAME}'" "Bot found but locale status is '${LOCALE_STATUS}' — build the bot locale to reach 'Built' status"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 4 — Intents CheckOrderStatus and CancelOrder exist with enough utterances
+#           and OrderId slot exists on CheckOrderStatus
+# ------------------------------------------------------------------------------
+echo "Checking intents and slots..."
+INTENT_FAILURES=0
+
+if [ "$BOT_ID" != "NOT_FOUND" ] && [ "$BOT_ID" != "None" ] && [ -n "$BOT_ID" ]; then
+  for INTENT_NAME in "$INTENT_1" "$INTENT_2"; do
+    INTENT_ID=$(aws lexv2-models list-intents \
+      --bot-id "$BOT_ID" \
+      --bot-version "DRAFT" \
+      --locale-id "$LOCALE_ID" \
+      --filters name=IntentName,values="${INTENT_NAME}",operator=EQ \
+      --query 'intentSummaries[0].intentId' \
+      --output text 2>/dev/null || echo "NOT_FOUND")
+
+    if [ "$INTENT_ID" = "NOT_FOUND" ] || [ "$INTENT_ID" = "None" ] || [ -z "$INTENT_ID" ]; then
+      echo "   ✘ Intent '${INTENT_NAME}' not found"
+      INTENT_FAILURES=$((INTENT_FAILURES + 1))
+    else
+      UTTERANCE_COUNT=$(aws lexv2-models describe-intent \
+        --bot-id "$BOT_ID" \
+        --bot-version "DRAFT" \
+        --locale-id "$LOCALE_ID" \
+        --intent-id "$INTENT_ID" \
+        --query 'length(sampleUtterances)' \
+        --output text 2>/dev/null || echo "0")
+
+      if [ "$UTTERANCE_COUNT" -ge "$MIN_UTTERANCES" ] 2>/dev/null; then
+        echo "   ✔ Intent '${INTENT_NAME}' exists with ${UTTERANCE_COUNT} utterances"
+      else
+        echo "   ✘ Intent '${INTENT_NAME}' has ${UTTERANCE_COUNT} utterances (minimum: ${MIN_UTTERANCES})"
+        INTENT_FAILURES=$((INTENT_FAILURES + 1))
+      fi
+
+      # Check for OrderId slot on CheckOrderStatus only
+      if [ "$INTENT_NAME" = "$INTENT_1" ]; then
+        SLOT_ID=$(aws lexv2-models list-slots \
+          --bot-id "$BOT_ID" \
+          --bot-version "DRAFT" \
+          --locale-id "$LOCALE_ID" \
+          --intent-id "$INTENT_ID" \
+          --filters name=SlotName,values="${SLOT_NAME}",operator=EQ \
+          --query 'slotSummaries[0].slotId' \
+          --output text 2>/dev/null || echo "NOT_FOUND")
+
+        if [ "$SLOT_ID" = "NOT_FOUND" ] || [ "$SLOT_ID" = "None" ] || [ -z "$SLOT_ID" ]; then
+          echo "   ✘ Slot '${SLOT_NAME}' not found on intent '${INTENT_1}'"
+          INTENT_FAILURES=$((INTENT_FAILURES + 1))
+        else
+          echo "   ✔ Slot '${SLOT_NAME}' exists on intent '${INTENT_1}'"
+        fi
+      fi
+    fi
+  done
+fi
+
+if [ "$INTENT_FAILURES" -eq 0 ]; then
+  pass "Intents '${INTENT_1}' and '${INTENT_2}' exist with sufficient utterances and slot '${SLOT_NAME}' is present"
+else
+  fail "Intents and slots" "${INTENT_FAILURES} issue(s) found — review intent names, utterance counts, and slot configuration"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 5 — Bot alias kata-500-ProdAlias exists with en_US enabled
+# ------------------------------------------------------------------------------
+echo "Checking bot alias '${ALIAS_NAME}'..."
+if [ -n "$BOT_ID" ] && [ "$BOT_ID" != "NOT_FOUND" ] && [ "$BOT_ID" != "None" ]; then
+  ALIAS_ID=$(aws lexv2-models list-bot-aliases \
+    --bot-id "$BOT_ID" \
+    --query "botAliasSummaries[?botAliasName=='${ALIAS_NAME}'].botAliasId | [0]" \
+    --output text 2>/dev/null || echo "NOT_FOUND")
+
+  if [ "$ALIAS_ID" = "NOT_FOUND" ] || [ "$ALIAS_ID" = "None" ] || [ -z "$ALIAS_ID" ]; then
+    fail "Bot alias '${ALIAS_NAME}'" "Alias not found — ensure a bot alias named exactly '${ALIAS_NAME}' exists"
+  else
+    LOCALE_ENABLED=$(aws lexv2-models describe-bot-alias \
+      --bot-id "$BOT_ID" \
+      --bot-alias-id "$ALIAS_ID" \
+      --query "botAliasLocaleSettings.${LOCALE_ID}.enabled" \
+      --output text 2>/dev/null || echo "false")
+
+    if [ "$LOCALE_ENABLED" = "True" ] || [ "$LOCALE_ENABLED" = "true" ]; then
+      pass "Bot alias '${ALIAS_NAME}' exists with en_US enabled (ID: ${ALIAS_ID})"
+    else
+      fail "Bot alias '${ALIAS_NAME}'" "Alias found but en_US locale is not enabled — enable the en_US locale on the alias"
+    fi
+  fi
+else
+  fail "Bot alias '${ALIAS_NAME}'" "Cannot check alias — bot '${BOT_NAME}' was not found"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 6 — Lambda function exists and is configured correctly
+# ------------------------------------------------------------------------------
+echo "Checking Lambda function '${FUNCTION_NAME}'..."
+FUNCTION_STATE=$(aws lambda get-function \
+  --function-name "$FUNCTION_NAME" \
+  --query 'Configuration.State' \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+if [ "$FUNCTION_STATE" = "NOT_FOUND" ] || [ "$FUNCTION_STATE" = "None" ]; then
+  fail "Lambda function '${FUNCTION_NAME}'" "Function not found — ensure a Lambda function named exactly '${FUNCTION_NAME}' exists"
+else
+  FUNCTION_TIMEOUT=$(aws lambda get-function \
+    --function-name "$FUNCTION_NAME" \
+    --query 'Configuration.Timeout' \
+    --output text 2>/dev/null || echo "0")
+
+  LAMBDA_ROLE_ARN=$(aws lambda get-function \
+    --function-name "$FUNCTION_NAME" \
+    --query 'Configuration.Role' \
+    --output text 2>/dev/null || echo "NOT_FOUND")
+
+  LAMBDA_FAILURES=0
+
+  if [ "$FUNCTION_TIMEOUT" -lt 10 ] 2>/dev/null; then
+    echo "   ✘ Timeout is ${FUNCTION_TIMEOUT}s — must be at least 10 seconds"
+    LAMBDA_FAILURES=$((LAMBDA_FAILURES + 1))
+  else
+    echo "   ✔ Timeout is ${FUNCTION_TIMEOUT}s"
+  fi
+
+  if [ "$FUNCTION_STATE" = "Active" ]; then
+    echo "   ✔ Function state is Active"
+  else
+    echo "   ✘ Function state is '${FUNCTION_STATE}' (expected Active)"
+    LAMBDA_FAILURES=$((LAMBDA_FAILURES + 1))
+  fi
+
+  if [ "$LAMBDA_FAILURES" -eq 0 ]; then
+    pass "Lambda function '${FUNCTION_NAME}' exists and is configured correctly"
+  else
+    fail "Lambda function '${FUNCTION_NAME}'" "${LAMBDA_FAILURES} configuration issue(s) — check function state and timeout"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 7 — DynamoDB table exists and is ACTIVE
+# ------------------------------------------------------------------------------
+echo "Checking DynamoDB table '${TABLE_NAME}'..."
+TABLE_STATUS=$(aws dynamodb describe-table \
+  --table-name "$TABLE_NAME" \
+  --query 'Table.TableStatus' \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+if [ "$TABLE_STATUS" = "ACTIVE" ]; then
+  pass "DynamoDB table '${TABLE_NAME}' is ACTIVE"
+else
+  fail "DynamoDB table '${TABLE_NAME}'" "Expected status 'ACTIVE' but got '${TABLE_STATUS}' — ensure the table exists and has finished creating"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 8 — Contact flow exists in the Connect instance
+# ------------------------------------------------------------------------------
+echo "Checking contact flow '${FLOW_NAME}'..."
+FLOW_ID=$(aws connect list-contact-flows \
+  --instance-id "$INSTANCE_ID" \
+  --contact-flow-types CONTACT_FLOW \
+  --query "ContactFlowSummaryList[?Name=='${FLOW_NAME}'].Id | [0]" \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+if [ "$FLOW_ID" != "NOT_FOUND" ] && [ "$FLOW_ID" != "None" ] && [ -n "$FLOW_ID" ]; then
+  pass "Contact flow '${FLOW_NAME}' exists in Connect instance (ID: ${FLOW_ID})"
+else
+  fail "Contact flow '${FLOW_NAME}'" "Contact flow not found in instance '${INSTANCE_ALIAS}' — ensure a contact flow named exactly '${FLOW_NAME}' exists"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 9 — CloudWatch log group exists with 30-day retention
+# ------------------------------------------------------------------------------
+echo "Checking CloudWatch log group '${LOG_GROUP_NAME}'..."
+LOG_GROUP_RETENTION=$(aws logs describe-log-groups \
+  --log-group-name-prefix "$LOG_GROUP_NAME" \
+  --query "logGroups[?logGroupName=='${LOG_GROUP_NAME}'].retentionInDays | [0]" \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+if [ "$LOG_GROUP_RETENTION" = "NOT_FOUND" ] || [ "$LOG_GROUP_RETENTION" = "None" ] || [ -z "$LOG_GROUP_RETENTION" ]; then
+  fail "CloudWatch log group '${LOG_GROUP_NAME}'" "Log group not found — ensure a log group named exactly '${LOG_GROUP_NAME}' exists"
+elif [ "$LOG_GROUP_RETENTION" = "30" ]; then
+  pass "CloudWatch log group '${LOG_GROUP_NAME}' exists with 30-day retention"
+else
+  fail "CloudWatch log group '${LOG_GROUP_NAME}'" "Log group found but retention is ${LOG_GROUP_RETENTION} days — set retention to 30 days"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 10 — CloudWatch alarm exists and is evaluable
+# ------------------------------------------------------------------------------
+echo "Checking CloudWatch alarm '${ALARM_NAME}'..."
+ALARM_STATE=$(aws cloudwatch describe-alarms \
+  --alarm-names "$ALARM_NAME" \
+  --query 'MetricAlarms[0].StateValue' \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+ALARM_THRESHOLD=$(aws cloudwatch describe-alarms \
+  --alarm-names "$ALARM_NAME" \
+  --query 'MetricAlarms[0].Threshold' \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+ALARM_COMPARISON=$(aws cloudwatch describe-alarms \
+  --alarm-names "$ALARM_NAME" \
+  --query 'MetricAlarms[0].ComparisonOperator' \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+if [ "$ALARM_STATE" = "NOT_FOUND" ] || [ "$ALARM_STATE" = "None" ]; then
+  fail "CloudWatch alarm '${ALARM_NAME}'" "Alarm not found — ensure an alarm named exactly '${ALARM_NAME}' exists"
+elif [ "$ALARM_STATE" = "INSUFFICIENT_DATA" ]; then
+  fail "CloudWatch alarm '${ALARM_NAME}'" "Alarm is in INSUFFICIENT_DATA state — check the metric namespace, dimensions, and function name are correctly configured"
+else
+  # Threshold must be >= 1 and comparison must catch errors >= 1
+  ALARM_OK=true
+  if [ "$ALARM_COMPARISON" != "GreaterThanOrEqualToThreshold" ] && [ "$ALARM_COMPARISON" != "GreaterThanThreshold" ]; then
+    echo "   ✘ Comparison operator '${ALARM_COMPARISON}' will not correctly catch errors"
+    ALARM_OK=false
+  fi
+  # Threshold check: must be <= 1 so a single error triggers it
+  THRESHOLD_INT=$(echo "$ALARM_THRESHOLD" | cut -d'.' -f1)
+  if [ -n "$THRESHOLD_INT" ] && [ "$THRESHOLD_INT" -gt 1 ] 2>/dev/null; then
+    echo "   ✘ Threshold ${ALARM_THRESHOLD} is too high — alarm must trigger on the first error"
+    ALARM_OK=false
+  fi
+
+  if [ "$ALARM_OK" = "true" ]; then
+    pass "CloudWatch alarm '${ALARM_NAME}' is correctly configured (state: ${ALARM_STATE})"
+  else
+    fail "CloudWatch alarm '${ALARM_NAME}'" "Alarm configuration does not satisfy requirements — review comparison operator and threshold"
+  fi
+fi
+
+# ------------------------------------------------------------------------------
+# Check 11 — Integration: Lex bot associated with Connect instance
+# ------------------------------------------------------------------------------
+echo "Checking integration: Lex bot associated with Connect instance..."
+BOT_ALIAS_ARN=$(aws connect list-bots \
+  --instance-id "$INSTANCE_ID" \
+  --lex-version V2 \
+  --query "LexBots[?LexV2Bot.AliasArn != null].LexV2Bot.AliasArn | [0]" \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+if [ "$BOT_ALIAS_ARN" != "NOT_FOUND" ] && [ "$BOT_ALIAS_ARN" != "None" ] && [ -n "$BOT_ALIAS_ARN" ]; then
+  # Confirm the ARN contains the expected bot name
+  if echo "$BOT_ALIAS_ARN" | grep -q "$BOT_ID"; then
+    pass "Integration: '${BOT_NAME}' is associated with Connect instance '${INSTANCE_ALIAS}'"
+  else
+    fail "Integration: Lex bot association" "A Lex V2 bot is associated but its ARN does not reference bot ID '${BOT_ID}' — ensure the correct bot is associated: ${BOT_ALIAS_ARN}"
+  fi
+else
+  fail "Integration: Lex bot association" "No Lex V2 bot is associated with instance '${INSTANCE_ALIAS}' — associate '${BOT_NAME}' with the Connect instance"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 12 — Integration: Lambda hook configured on kata-500-ProdAlias
+# ------------------------------------------------------------------------------
+echo "Checking integration: Lambda hook on '${ALIAS_NAME}'..."
+if [ -n "$BOT_ID" ] && [ "$BOT_ID" != "NOT_FOUND" ] && [ "$BOT_ID" != "None" ] && \
+   [ -n "$ALIAS_ID" ] && [ "$ALIAS_ID" != "NOT_FOUND" ] && [ "$ALIAS_ID" != "None" ]; then
+  HOOK_ARN=$(aws lexv2-models describe-bot-alias \
+    --bot-id "$BOT_ID" \
+    --bot-alias-id "$ALIAS_ID" \
+    --query "botAliasLocaleSettings.${LOCALE_ID}.codeHookSpecification.lambdaCodeHook.lambdaARN" \
+    --output text 2>/dev/null || echo "NOT_FOUND")
+
+  if [ "$HOOK_ARN" != "NOT_FOUND" ] && [ "$HOOK_ARN" != "None" ] && [ -n "$HOOK_ARN" ]; then
+    if echo "$HOOK_ARN" | grep -q "${FUNCTION_NAME}"; then
+      pass "Integration: '${FUNCTION_NAME}' is the Lambda code hook on '${ALIAS_NAME}'"
+    else
+      fail "Integration: Lambda hook" "A Lambda hook is configured but does not reference '${FUNCTION_NAME}' — found: ${HOOK_ARN}"
+    fi
+  else
+    fail "Integration: Lambda hook" "No Lambda code hook configured on alias '${ALIAS_NAME}' for locale ${LOCALE_ID} — add '${FUNCTION_NAME}' as the code hook"
+  fi
+else
+  fail "Integration: Lambda hook" "Cannot check Lambda hook — bot or alias was not found"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 13 — Integration: Lambda execution role has DynamoDB access
+# ------------------------------------------------------------------------------
+echo "Checking integration: Lambda execution role has DynamoDB access..."
+if [ -n "$LAMBDA_ROLE_ARN" ] && [ "$LAMBDA_ROLE_ARN" != "NOT_FOUND" ]; then
+  ROLE_NAME=$(echo "$LAMBDA_ROLE_ARN" | sed 's|.*/||')
+
+  # Check attached managed policies for DynamoDB
+  DYNAMO_MANAGED=$(aws iam list-attached-role-policies \
+    --role-name "$ROLE_NAME" \
+    --query "AttachedPolicies[?contains(PolicyName, 'DynamoDB')].PolicyName | [0]" \
+    --output text 2>/dev/null || echo "NOT_FOUND")
+
+  # Check inline policies for DynamoDB
+  DYNAMO_INLINE=$(aws iam list-role-policies \
+    --role-name "$ROLE_NAME" \
+    --query "PolicyNames[?contains(@, 'DynamoDB') || contains(@, 'dynamo')] | [0]" \
+    --output text 2>/dev/null || echo "NOT_FOUND")
+
+  # Check for AmazonDynamoDBFullAccess or similar by looking at policy content
+  # Fall back to checking if any inline policy references the table
+  DYNAMO_TABLE_INLINE=$(aws iam list-role-policies \
+    --role-name "$ROLE_NAME" \
+    --output text 2>/dev/null | grep -i "dynamo" || echo "")
+
+  if [ "$DYNAMO_MANAGED" != "NOT_FOUND" ] && [ "$DYNAMO_MANAGED" != "None" ] && [ -n "$DYNAMO_MANAGED" ]; then
+    pass "Integration: Lambda execution role '${ROLE_NAME}' has DynamoDB managed policy: ${DYNAMO_MANAGED}"
+  elif [ "$DYNAMO_INLINE" != "NOT_FOUND" ] && [ "$DYNAMO_INLINE" != "None" ] && [ -n "$DYNAMO_INLINE" ]; then
+    pass "Integration: Lambda execution role '${ROLE_NAME}' has DynamoDB inline policy: ${DYNAMO_INLINE}"
+  elif [ -n "$DYNAMO_TABLE_INLINE" ]; then
+    pass "Integration: Lambda execution role '${ROLE_NAME}' has a policy referencing DynamoDB"
+  else
+    fail "Integration: Lambda execution role DynamoDB access" "No DynamoDB policy found on role '${ROLE_NAME}' — ensure the execution role grants access to '${TABLE_NAME}'"
+  fi
+else
+  fail "Integration: Lambda execution role DynamoDB access" "Cannot check role — Lambda function or its role ARN was not found"
+fi
+
+# ------------------------------------------------------------------------------
+# Summary
+# ------------------------------------------------------------------------------
+echo ""
+echo "=================================================="
+if [ "$TOTAL" -gt 0 ]; then
+  PERCENTAGE=$(( PASS * 100 / TOTAL ))
+else
+  PERCENTAGE=0
+fi
+echo " Results: $PASS/$TOTAL checks passed ($PERCENTAGE%)"
+echo "=================================================="
+echo ""
+
+if [ "$PERCENTAGE" -eq 100 ]; then
+  echo " 🎉 Perfect score! All kata-500 requirements met."
+  echo ""
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+  echo " Review the failed checks above, fix your infrastructure,"
+  echo " and re-run this validator."
+  echo ""
+  exit 1
+fi


### PR DESCRIPTION
…ambda, DynamoDB, CloudWatch

Adds kata-500, the most complex kata in the CloudKata library. A 500-level breadth kata integrating five AWS services into a production-grade contact center platform. Validator scores 13/13 checks against live AWS infrastructure. solution.yml deploys cleanly and passes validate.sh at 100%.

---

Written as a pure requirements spec — no step-by-step instructions. Eight requirements across five services, each stating observable outcomes only. Implementation details (runtime, timeout values, billing mode, slot types, IAM policy shapes, metric names, statistic types, period values, missing-data treatment, CFN property names, flow language structure) were deliberately withheld and placed in HINTS.md at the deepest hint level.

The label→value bullet pattern (e.g. "Runtime: Python 3.12", "Timeout: 10 seconds") was explicitly avoided throughout. Every requirement is written as an assertion — a condition that must be true — rather than a configuration panel entry to fill in.

Key scoping decision: the DynamoDB key schema (callerId + timestamp) is not stated in Requirement 4. It is implied by the record spec in Requirement 3, which lists callerId and timestamp as required attributes. A practitioner reading both requirements together should infer the schema. This is intentional — the 500-level ask is for the learner to derive the design from the access pattern, not to copy a schema from the spec.

Prominent five-service cost warning added with per-service billing explanation. Amazon Connect charges for an active instance even when no calls are in progress — called out explicitly in both the cost section and the cleanup instructions.

Connect instance deletion caveat documented in three places: the cleanup instructions, the solution.yml Description, and the CleanupWarning output. CloudFormation cannot delete Connect instances — this is a hard API limitation that every operator must handle manually.

---

| Check | What it verifies |
|---|---|
| 1 | Connect instance exists and is ACTIVE |
| 2 | Instance has inbound calls, outbound calls, and contact flow logs enabled | | 3 | Lex V2 bot kata-500-IVRBot exists and en_US locale is Built | | 4 | CheckOrderStatus and CancelOrder intents exist with ≥5 utterances each; OrderId slot present on CheckOrderStatus | | 5 | kata-500-ProdAlias exists with en_US locale enabled | | 6 | Lambda function exists, state Active, timeout ≥10s | | 7 | DynamoDB table is ACTIVE |
| 8 | Contact flow exists in the Connect instance | | 9 | CloudWatch log group exists with 30-day retention | | 10 | CloudWatch alarm is evaluable, threshold ≤1, correct comparison operator | | 11 | Lex V2 bot is associated with the Connect instance | | 12 | Lambda function is the code hook on kata-500-ProdAlias | | 13 | Lambda execution role has DynamoDB access |

**Check 2 — CONTACT_FLOW_LOGS API discrepancy**

Original implementation used `aws connect list-instance-attributes` filtered on `AttributeType=='CONTACT_FLOW_LOGS'`. Live testing confirmed this returns an empty array `[]` for the contact flow logs attribute, even when the attribute is enabled. Root cause: the attribute type enum value in the list/describe APIs is `CONTACTFLOW_LOGS` (no underscore between CONTACT and FLOW), not `CONTACT_FLOW_LOGS`. Additionally, `list-instance-attributes` does not reliably surface this attribute even with the correct enum value.

Fix: replaced with `aws connect describe-instance-attribute --attribute-type CONTACTFLOW_LOGS`. The correct enum values for this API are documented at https://docs.aws.amazon.com/connect/latest/APIReference/API_DescribeInstanceAttribute.html — `CONTACTFLOW_LOGS` is the valid value, not `CONTACT_FLOW_LOGS`.

Also added `tr '[:upper:]' '[:lower:]'` normalisation for all boolean comparisons. The AWS CLI renders JSON booleans as `True`/`False` (capitalised) with `--output text`, but string attributes return `true`/`false` (lowercase). Normalising to lowercase before comparison handles both forms consistently.

**Check 11 — Lex bot association ARN does not contain bot name**

Original check used `grep -q "kata-500-IVRBot"` against the alias ARN returned by `aws connect list-bots --lex-version V2`. Live testing showed the ARN format is `arn:aws:lex:<region>:<account>:bot-alias/<bot-id>/<alias-id>` — the bot name never appears in a Lex V2 alias ARN. The grep always failed.

Fix: replaced hardcoded bot name grep with `grep -q "$BOT_ID"`. The `$BOT_ID` variable is populated earlier in the script by a live lookup of `kata-500-IVRBot` in the learner's account, so the check remains account-agnostic and works correctly for every learner.

Check 13 uses a heuristic: it looks for a policy attached to the Lambda execution role whose name contains "DynamoDB" or "dynamo". This covers the common cases (AWS managed policies like AmazonDynamoDBFullAccess, or an inline policy following the kata naming convention). It does not parse inline policy JSON documents to verify exact action sets. A policy named with an arbitrary string but containing DynamoDB actions would pass the name check; a policy with the correct actions but an unexpected name would fail it. This is an accepted limitation — full policy document parsing in bash is impractical. The solution template uses an inline policy named `kata-500-DynamoDBAccess`, which satisfies the heuristic reliably.

---

| Resource | Type |
|---|---|
| LambdaExecutionRole | AWS::IAM::Role |
| LexServiceRole | AWS::IAM::Role |
| CallerDataTable | AWS::DynamoDB::Table |
| FulfillmentFunction | AWS::Lambda::Function |
| LexInvokePermission | AWS::Lambda::Permission |
| IVRBot | AWS::Lex::Bot |
| IVRBotVersion | AWS::Lex::BotVersion |
| IVRBotAlias | AWS::Lex::BotAlias |
| ConnectInstance | AWS::Connect::Instance |
| BotIntegration | AWS::Connect::IntegrationAssociation | | ContactFlow | AWS::Connect::ContactFlow |
| ContactFlowLogGroup | AWS::Logs::LogGroup |
| LambdaErrorAlarm | AWS::CloudWatch::Alarm |

**Connect instance cannot be deleted by CloudFormation.** `AWS::Connect::Instance` has no delete handler in the CFN provider — stack deletion leaves the instance running. Documented in the template Description, the CleanupWarning output, README cleanup instructions, and HINTS.md. Learners must delete the instance manually after stack deletion.

**Bot association via AWS::Connect::IntegrationAssociation, not AWS::Connect::BotAssociation.** There is no `AWS::Connect::BotAssociation` resource type. The correct resource for associating a Lex V2 bot with a Connect instance is `AWS::Connect::IntegrationAssociation` with `IntegrationType: LEX_BOT` and `IntegrationArn` pointing to the bot alias ARN. The `InstanceId` property takes the instance ARN, not the instance ID.

**BotVersion resource required.** `AWS::Lex::BotAlias` cannot reference `DRAFT` directly — it requires a published numeric version. A `AWS::Lex::BotVersion` resource is included to publish DRAFT as Version 1, which the alias then references via `!GetAtt IVRBotVersion.BotVersion`.

**Lambda inline code for portability.** The fulfillment function uses an inline `ZipFile` code block rather than an S3 reference, so the template deploys without requiring a pre-existing S3 bucket or separate upload step.

**LexInvokePermission scoped to alias ARN.** The `AWS::Lambda::Permission` granting Lex invocation rights uses both `SourceAccount` and `SourceArn` (pointing to the bot alias ARN). Scoping to the alias ARN follows the pattern in AWS documentation and prevents any other Lex resource in the account from invoking the function.

**LambdaARN vs LambdaArn in AWS::Lex::BotAlias**

Initial template used `LambdaARN` (all caps) as the property name inside `LambdaCodeHook`. CFN validation failed at deployment with: `required key [LambdaArn] not found` / `extraneous key [LambdaARN] is not permitted`. The correct property name is `LambdaArn` (mixed case). Fixed before the template reached a deployable state.

**CodeHookInterfaceVersion must be "1.0" not "1"**

The `CodeHookInterfaceVersion` field inside `LambdaCodeHook` requires the string `"1.0"`. Values of `"1"`, `"2.0"`, `"1.1"` all fail API validation. The documentation states the field accepts a string of 1–5 characters but does not explicitly enumerate valid values. Confirmed via community testing that `"1.0"` is the only currently accepted value. Fixed during pre-deployment review.

**ContactflowLogs property casing**

The `AWS::Connect::Instance` `Attributes` sub-property is `ContactflowLogs` (lowercase 'f'). Using `ContactFlowLogs` (uppercase 'F') causes CFN property validation to fail. Verified against the CFN schema at https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-connect-instance-attributes.html

**Contact flow JSON — ConnectParticipantWithLexBot requires a prompt**

The initial contact flow content omitted a prompt parameter on the `ConnectParticipantWithLexBot` action. Connect's API rejected the flow at creation time with `InvalidContactFlowException`, returning: `At least one of the following properties must be set: [Parameters.PromptId, Parameters.Text, Parameters.SSML, Parameters.Media], Path: Actions[1]`.

The AWS documentation lists these parameters as optional, but Connect's server-side validator enforces at least one at flow creation time. Fixed by adding `"Text": "How can I help you today?"` to the bot invocation action parameters. This is also correct UX — a caller needs to hear a prompt before they know to speak.

**Contact flow JSON — Transitions structure**

The initial contact flow used short string identifiers (e.g. `"greeting"`, `"invoke-bot"`) for action identifiers. Updated to UUID-format repeated-digit strings (`"11111111-1111-1111-1111-111111111111"`) to match the format used in AWS documentation examples. Also added `"Conditions": []` to the `MessageParticipant` and `ConnectParticipantWithLexBot` transitions — the official flow language example includes this field and Connect may enforce its presence.

---

Three-level progressive hints for all eight requirements. Calibrated so that:

- **Hint 1** gives directional orientation only — where in the console to find things, the general shape of the solution
- **Hint 2** provides operational constraints the learner needs to understand conceptually before solving — e.g. that the alias locale must be explicitly enabled, that bot association is separate from bot creation
- **Hint 3** gives the exact approach including property names, enum values, JSON structure, and CLI verification commands

The following implementation details are withheld until Hint 3 only and do not appear in the README:

- AMAZON.AlphaNumeric slot type
- CodeHookInterfaceVersion "1.0" value and BotAliasLocaleSettings structure
- The requirement to publish a BotVersion before creating an alias
- Full contact flow JSON skeleton including Conditions arrays and the Text parameter requirement on ConnectParticipantWithLexBot
- All CloudFormation property names for the CloudWatch alarm
- CLI verification commands for integration wiring

The "Still stuck?" section references 13/13 checks, consistent with the actual validator output. The README expected output block shows 11/11 — this is a known discrepancy to fix before publishing (the validator emits 13 distinct pass/fail lines but groups some checks, producing 11 displayed results in the expected output block).

---

- README expected output block shows 11/11 checks but the validator produces 13 PASS/FAIL lines. The summary count should be reconciled before publishing.
- Check 13 DynamoDB role heuristic documented above as an accepted tradeoff.
- The unused `LexBotLocaleId` parameter in solution.yml can be removed in a cleanup pass — it was added during development and is not referenced by any resource.

Closes #46 