### PR TITLE
feat(kata-205): add Lambda + SQS event-source-mapping kata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -538,7 +538,7 @@ The following katas are planned for the CloudKata library. All are open for comm
 | [kata-202](./katas/kata-202-lexv2-advanced/) | Amazon Lex V2 Advanced — Versioning, Aliases & Lambda Fulfillment | 200 | Depth | Lex V2, Lambda | Published |
 | [kata-203](./katas/kata-203-api-gateway-lambda-rest/)   | API Gateway + Lambda — REST API & Proxy Integration | 200 | Breadth | API Gateway, Lambda | Published |
 | [kata-204](./katas/kata-204-lambda-event-notification-and-triggers/) | S3 + Lambda — Event Notifications & Triggers | 200 | Breadth | S3, Lambda | Published |
-| kata-205 | Lambda + SQS — Event Source Mapping & Error Handling | 200 | Breadth | Lambda, SQS | Open |
+| [kata-205](./katas/kata-205-lambda-sqs-event-source/) | Lambda + SQS — Event Source Mapping & Error Handling | 200 | Breadth | Lambda, SQS | Published |
 | kata-206 | RDS Basics — Instances, Subnet Groups & Parameter Groups | 200 | Depth | RDS | Open |
 | [kata-207](./katas/kata-207-cloudtrail-basics/)  | CloudTrail Basics — Trails, Events & Audit Logging | 200 | Depth | CloudTrail, S3 | Published |
 

--- a/katas/kata-205-lambda-sqs-event-source/HINTS.md
+++ b/katas/kata-205-lambda-sqs-event-source/HINTS.md
@@ -1,0 +1,293 @@
+# kata-205 Hints — Lambda + SQS: Event Source Mapping & Error Handling
+
+> ⚠️ **Spoiler warning.** Each hint section reveals progressively more detail.
+> Try to solve each requirement on your own before opening a hint. The learning
+> is in the struggle.
+
+---
+
+## How to use these hints
+
+Hints are organized by requirement number matching the README. Each requirement
+has up to three levels:
+
+- **Hint 1** — a nudge in the right direction
+- **Hint 2** — more specific guidance
+- **Hint 3** — the exact approach (near-solution level)
+
+---
+
+## Requirement 1 — Processing queue
+
+<details>
+<summary>Hint 1 — What kind of queue</summary>
+
+This is an ordinary **standard** SQS queue — nothing special about it on its
+own. What makes it the "processing queue" is that the function will consume
+from it and that it will carry a redrive policy (Requirement 3). Naming a queue
+without a `.fifo` suffix makes it a standard queue, which is what you want here.
+
+</details>
+
+<details>
+<summary>Hint 2 — Naming and the ARN you'll need later</summary>
+
+The queue must be named exactly `kata-205-ProcessingQueue`. Once it exists,
+note its **ARN** — you will need it when you wire up the event source mapping
+in Requirement 6. The ARN looks like
+`arn:aws:sqs:<region>:<account-id>:kata-205-ProcessingQueue`.
+
+</details>
+
+<details>
+<summary>Hint 3 — CLI</summary>
+
+```bash
+aws sqs create-queue --queue-name kata-205-ProcessingQueue
+
+# Fetch its ARN for later
+aws sqs get-queue-attributes \
+  --queue-url <processing-queue-url> \
+  --attribute-names QueueArn \
+  --query 'Attributes.QueueArn' --output text
+```
+
+Hold off on the visibility timeout for a moment — it interacts with the
+function timeout, which is covered in Requirement 6, Hint 3.
+
+</details>
+
+---
+
+## Requirement 2 — Dead-letter queue
+
+<details>
+<summary>Hint 1 — There is nothing structurally special about a DLQ</summary>
+
+A dead-letter queue is just another standard queue. A queue only *becomes* a
+dead-letter queue because a **source** queue names it as its redrive target
+(Requirement 3). So create this one exactly like the processing queue, then
+wire the relationship separately.
+
+</details>
+
+<details>
+<summary>Hint 2 — Create it first</summary>
+
+Create the DLQ **before** the processing queue, or at least before you set the
+redrive policy — the redrive policy on the processing queue needs the DLQ's
+ARN. A longer message retention on the DLQ is good practice, since the whole
+point is to keep failed messages around long enough to inspect them.
+
+</details>
+
+<details>
+<summary>Hint 3 — CLI</summary>
+
+```bash
+aws sqs create-queue \
+  --queue-name kata-205-DeadLetterQueue \
+  --attributes MessageRetentionPeriod=1209600   # 14 days, the maximum
+
+# Fetch its ARN — you'll reference it in the redrive policy
+aws sqs get-queue-attributes \
+  --queue-url <dlq-url> \
+  --attribute-names QueueArn \
+  --query 'Attributes.QueueArn' --output text
+```
+
+</details>
+
+---
+
+## Requirement 3 — Failed-message routing
+
+<details>
+<summary>Hint 1 — This lives on the source queue</summary>
+
+The routing is configured on the **processing queue**, not on the dead-letter
+queue. Look for the "dead-letter queue" / "redrive policy" settings on
+`kata-205-ProcessingQueue`. The DLQ itself needs no configuration for this.
+
+</details>
+
+<details>
+<summary>Hint 2 — Two pieces of information</summary>
+
+A redrive policy has two parts: **which** queue failed messages go to (the DLQ
+ARN) and **after how many attempts** they are moved there. That second number
+is the maximum receive count — how many times a message can be received and
+returned to the queue before SQS gives up and moves it to the DLQ.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact shape</summary>
+
+The `RedrivePolicy` queue attribute is a JSON object with exactly these keys:
+
+```json
+{"deadLetterTargetArn":"<dlq-arn>","maxReceiveCount":3}
+```
+
+Via CLI:
+
+```bash
+aws sqs set-queue-attributes \
+  --queue-url <processing-queue-url> \
+  --attributes '{"RedrivePolicy":"{\"deadLetterTargetArn\":\"<dlq-arn>\",\"maxReceiveCount\":\"3\"}"}'
+```
+
+The validator confirms the target ARN resolves to `kata-205-DeadLetterQueue`
+and that `maxReceiveCount` is at least 1. A value of `3` is a sensible default.
+
+</details>
+
+---
+
+## Requirement 4 — Processing function
+
+<details>
+<summary>Hint 1 — Use the code you were given</summary>
+
+This is not a coding kata. Create a Python Lambda function named
+`kata-205-ProcessorFunction` and paste in the handler from the README. It just
+logs each message so the invocation is observable.
+
+</details>
+
+<details>
+<summary>Hint 2 — The handler string must match how you deploy</summary>
+
+The handler identifier is `<file>.<function>`. If you author in the console,
+the default file is `lambda_function.py`, so the handler is
+`lambda_function.lambda_handler`. If you deploy inline via CloudFormation, the
+file is named `index`, so the handler is `index.lambda_handler`. Mismatching
+these is the most common reason a function "exists but never runs."
+
+</details>
+
+<details>
+<summary>Hint 3 — Runtime and the timeout that matters</summary>
+
+Use a current Python runtime such as `python3.12`. The function's **timeout**
+is worth setting deliberately — not because the validator checks it, but
+because it constrains the queue's visibility timeout (Requirement 6, Hint 3).
+A 30-second function timeout is comfortable for this workload.
+
+</details>
+
+---
+
+## Requirement 5 — Function consume permissions
+
+<details>
+<summary>Hint 1 — Logging permission is not enough</summary>
+
+A brand-new Lambda execution role can usually write logs but cannot touch SQS.
+To drain a queue, the role needs permission to **receive**, **delete**, and
+**read the attributes of** that queue. Without these, the event source mapping
+cannot poll and the function never runs.
+
+</details>
+
+<details>
+<summary>Hint 2 — There is a purpose-built managed policy</summary>
+
+You don't have to hand-write these permissions. AWS provides a managed policy
+specifically for Lambda functions that consume from SQS. It bundles the three
+SQS actions above together with CloudWatch Logs write access, so it can replace
+the basic execution policy entirely.
+
+</details>
+
+<details>
+<summary>Hint 3 — Exact policy</summary>
+
+Attach this managed policy to the function's execution role:
+
+```
+arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole
+```
+
+It grants `sqs:ReceiveMessage`, `sqs:DeleteMessage`, `sqs:GetQueueAttributes`,
+plus `logs:CreateLogGroup`, `logs:CreateLogStream`, and `logs:PutLogEvents`.
+
+If you prefer a scoped custom policy instead, grant those three `sqs:` actions
+on the `kata-205-ProcessingQueue` ARN. The validator accepts either the managed
+policy or a custom policy that grants the receive action.
+
+</details>
+
+---
+
+## Requirement 6 — Event source mapping
+
+<details>
+<summary>Hint 1 — What connects the queue to the function</summary>
+
+The link between SQS and Lambda is an **event source mapping** (in the console
+it appears as an SQS **trigger** on the function). You create it from the Lambda
+side: add an SQS trigger and point it at `kata-205-ProcessingQueue`. Lambda then
+polls the queue for you — there is no schedule or manual step to configure.
+
+</details>
+
+<details>
+<summary>Hint 2 — It must be enabled, and it reads in batches</summary>
+
+The mapping must be **enabled** to poll. It delivers messages to the function
+in batches; the batch size sets how many messages arrive per invocation. The
+validator checks that a mapping links the queue to the function and that its
+state is `Enabled`.
+
+</details>
+
+<details>
+<summary>Hint 3 — CLI, and the timeout gotcha that trips everyone</summary>
+
+```bash
+aws lambda create-event-source-mapping \
+  --function-name kata-205-ProcessorFunction \
+  --event-source-arn <processing-queue-arn> \
+  --batch-size 10 \
+  --enabled
+```
+
+For a standard SQS source the maximum batch size is **10** (going higher
+requires a batching window).
+
+**The gotcha:** the processing queue's **visibility timeout must be at least
+the function timeout — AWS recommends at least 6x it.** With a 30-second
+function timeout, set the queue visibility timeout to around 180 seconds. If it
+is too low, a message becomes visible again while the function is still
+processing it, so it gets picked up a second time and eventually lands in the
+DLQ even though nothing actually failed.
+
+If mapping creation fails with a message about the role not being allowed to
+call `ReceiveMessage`, finish Requirement 5 first, then create the mapping —
+the permission must exist before the mapping can be established.
+
+</details>
+
+---
+
+## Still stuck?
+
+The complete working solution is in [solution.yml](./solution.yml).
+
+Deploy it with:
+
+```bash
+aws cloudformation deploy \
+  --template-file solution.yml \
+  --stack-name kata-205-solution \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+`CAPABILITY_NAMED_IAM` is required because the template creates an execution
+role with an explicit name.
+
+Then re-run `validate.sh`. A correctly deployed solution should score 6/6.
+Study the solution to understand what you missed, then tear it down (delete the
+CloudFormation stack) and try again from scratch.

--- a/katas/kata-205-lambda-sqs-event-source/README.md
+++ b/katas/kata-205-lambda-sqs-event-source/README.md
@@ -1,0 +1,248 @@
+---
+id: kata-205
+title: "Lambda + SQS — Event Source Mapping & Error Handling"
+level: 200
+type: breadth
+services:
+  - lambda
+  - sqs
+tags:
+  - lambda
+  - sqs
+  - event-driven
+  - event-source-mapping
+  - dead-letter-queue
+  - error-handling
+  - breadth
+  - intermediate
+estimated_time: 1 hour
+estimated_cost: "$0.00 - $1.00"
+author: Faisal Akhtar
+github: https://github.com/fakhtar
+---
+
+# kata-205 — Lambda + SQS: Event Source Mapping & Error Handling
+
+## Overview
+
+In this kata you will build an event-driven message-processing pipeline in
+which an AWS Lambda function automatically consumes messages from an Amazon SQS
+queue. You will connect the queue to the function with an event source mapping,
+grant the function the permissions it needs to consume from the queue, and add
+a dead-letter queue so that messages which repeatedly fail processing are
+captured instead of lost. This kata covers the core asynchronous worker
+pattern behind most decoupled, resilient serverless systems: a queue absorbing
+work, a function draining it in batches, and a safety net for failures.
+
+---
+
+## Prerequisites
+
+- An active AWS account
+- Access to AWS CloudShell
+- IAM permissions to create and manage SQS queues, Lambda functions, IAM
+  roles, event source mappings, and CloudWatch Logs
+- Familiarity with the AWS Console or CLI
+
+---
+
+## Cost & Time
+
+| | |
+|---|---|
+| ⏱ Estimated Time | ~1 hour |
+| 💰 Estimated Cost | ~$0.00 - $1.00 |
+
+> ⚠️ **Cost Warning:** These are estimates only. Actual costs depend on your
+> AWS region, account tier, and how quickly you complete the kata. A modest
+> number of messages and function invocations fall well within the AWS Free
+> Tier; CloudWatch Logs storage may incur a negligible charge. If you leave
+> infrastructure running beyond this kata session, costs will continue to
+> accumulate. All charges are your responsibility. Always run cleanup
+> instructions when finished.
+
+---
+
+## Requirements
+
+Build the following infrastructure in your AWS account. All resource names
+must follow the naming convention: `kata-205-ResourceName`
+
+You are given a spec, not a tutorial. Use the AWS Console, CLI, IaC, or any
+tools you choose to meet these requirements. Consult the AWS documentation,
+use AI assistants, or search the web — whatever you would use on the job.
+
+---
+
+### Requirement 1 — Processing queue
+
+Work items enter the system through a dedicated SQS queue.
+
+- **Queue name:** `kata-205-ProcessingQueue`
+- This queue is the source that the function drains.
+
+---
+
+### Requirement 2 — Dead-letter queue
+
+Messages that cannot be processed must have somewhere to go instead of being
+lost or retried forever.
+
+- **Queue name:** `kata-205-DeadLetterQueue`
+- This is a separate queue whose only job is to hold messages that failed
+  processing so they can be inspected later.
+
+---
+
+### Requirement 3 — Failed-message routing
+
+The processing queue must protect itself from poison messages.
+
+- After a message has been received and returned to the processing queue a
+  **bounded number of times without being successfully processed**, it must be
+  moved automatically to `kata-205-DeadLetterQueue`.
+- The routing must be a property of the processing queue itself — no custom
+  code should be responsible for shuffling failed messages.
+
+---
+
+### Requirement 4 — Processing function
+
+Messages must be consumed and handled by a Lambda function.
+
+- **Function name:** `kata-205-ProcessorFunction`
+- The function receives batches of messages and processes each one. For this
+  kata it only needs to record that it handled each message, so its work is
+  observable in logs — the function code is provided below (this is **not** a
+  coding kata).
+
+---
+
+### Requirement 5 — Function consume permissions
+
+The function must be allowed to drain the queue.
+
+- The function's execution role must **permit it to receive messages from,
+  delete messages from, and read the attributes of `kata-205-ProcessingQueue`.**
+- Without these permissions the connection between the queue and the function
+  cannot function, even when everything else is wired correctly.
+
+---
+
+### Requirement 6 — Event source mapping
+
+The function must consume from the queue on its own, continuously.
+
+- The function must be connected to `kata-205-ProcessingQueue` by an **active
+  event source mapping** that delivers messages to the function in **batches**.
+- Consumption must be automatic and ongoing: there must be no manual polling,
+  schedule, or trigger step between a message arriving and the function
+  receiving it.
+
+---
+
+## Function Code
+
+This is not a coding kata. Deploy the following handler as the code for
+`kata-205-ProcessorFunction`. It iterates the batch of SQS records and prints a
+distinctive line per message so that processing is easy to observe in
+CloudWatch Logs.
+
+```python
+def lambda_handler(event, context):
+    records = event.get("Records", [])
+    for record in records:
+        message_id = record.get("messageId")
+        body = record.get("body")
+        print(f"kata-205 processed message {message_id}: {body}")
+    return {"processed": len(records)}
+```
+
+---
+
+## Running the Validator
+
+Once you have built the required infrastructure, open AWS CloudShell and
+upload or copy `validate.sh` to your CloudShell environment, then run:
+
+```bash
+sed -i 's/\r//' validate.sh
+chmod +x validate.sh
+./validate.sh
+```
+
+The validator checks your live AWS infrastructure and reports a score.
+A fully passing result looks like this:
+
+```
+==================================================
+ CloudKata Validator — kata-205
+ Lambda + SQS: Event Source Mapping & Error Handling
+==================================================
+
+✅ PASS — SQS queue 'kata-205-ProcessingQueue' exists
+✅ PASS — Dead-letter queue 'kata-205-DeadLetterQueue' exists
+✅ PASS — Processing queue routes failed messages to the dead-letter queue
+✅ PASS — Lambda function 'kata-205-ProcessorFunction' exists
+✅ PASS — Function's execution role permits consuming from the queue
+✅ PASS — Event source mapping connects the queue to the function and is enabled
+
+==================================================
+ Results: 6/6 checks passed (100%)
+==================================================
+
+ 🎉 Perfect score! All requirements met.
+```
+
+---
+
+## Cleanup
+
+Always clean up your resources when you are finished. Follow these steps
+in order.
+
+### Step 1 — Delete CloudFormation stacks (if applicable)
+
+If you deployed `solution.yml`, delete that stack first via CloudFormation.
+Stack deletion removes the queues, the function, the event source mapping, and
+the execution role automatically.
+
+- Go to the AWS CloudFormation console
+- Select the stack created for this kata
+- Choose **Delete** and wait for deletion to complete before proceeding
+
+Via CLI:
+```bash
+aws cloudformation delete-stack --stack-name kata-205-solution
+aws cloudformation wait stack-delete-complete --stack-name kata-205-solution
+```
+
+### Step 2 — Manual Cleanup
+
+If you created any resources manually via the console or the CLI, it is your
+responsibility to delete them to avoid incurring ongoing costs. Work backwards
+and remove: the event source mapping, `kata-205-ProcessorFunction`, its
+execution role, both SQS queues, and the CloudWatch log group
+`/aws/lambda/kata-205-ProcessorFunction`.
+
+Read the instructions again and work backwards to ensure you have deleted all
+created resources.
+
+### Step 3 — Verify in the console
+
+Confirm in the SQS and Lambda consoles that `kata-205-ProcessingQueue`,
+`kata-205-DeadLetterQueue`, and `kata-205-ProcessorFunction` no longer exist.
+
+> ⚠️ If you leave infrastructure running, costs will continue to accumulate
+> and are your responsibility.
+
+---
+
+## Hints & Solution
+
+Stuck? Refer to [HINTS.md](./HINTS.md) for progressive hints without full
+spoilers.
+
+The complete solution is available in [solution.yml](./solution.yml).
+Deploying `solution.yml` and re-running `validate.sh` should produce a
+score of 100%.

--- a/katas/kata-205-lambda-sqs-event-source/solution.yml
+++ b/katas/kata-205-lambda-sqs-event-source/solution.yml
@@ -1,0 +1,187 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  CloudKata kata-205 — Lambda + SQS: Event Source Mapping & Error Handling.
+  Solution template. Deploys all infrastructure required to pass the
+  kata-205 validator at 100%.
+
+# =============================================================================
+# Resources
+# =============================================================================
+
+Resources:
+
+  # ---------------------------------------------------------------------------
+  # Dead-letter queue
+  # Holds messages that fail processing after maxReceiveCount attempts.
+  # ---------------------------------------------------------------------------
+  DeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: kata-205-DeadLetterQueue
+      MessageRetentionPeriod: 1209600
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-205
+
+  # ---------------------------------------------------------------------------
+  # Processing queue
+  # The source the function drains. Its redrive policy routes messages that
+  # fail processing three times to the dead-letter queue.
+  #
+  # VisibilityTimeout (180s) is deliberately >= the function timeout (30s).
+  # For SQS event source mappings AWS requires the queue visibility timeout to
+  # be at least the function timeout, and recommends at least 6x it, so that a
+  # message is not redelivered while it is still being processed.
+  # ---------------------------------------------------------------------------
+  ProcessingQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: kata-205-ProcessingQueue
+      VisibilityTimeout: 180
+      MessageRetentionPeriod: 345600
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt DeadLetterQueue.Arn
+        maxReceiveCount: 3
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-205
+
+  # ---------------------------------------------------------------------------
+  # Lambda execution role
+  # AWSLambdaSQSQueueExecutionRole grants sqs:ReceiveMessage, sqs:DeleteMessage,
+  # sqs:GetQueueAttributes, and CloudWatch Logs write permissions in one policy.
+  # ---------------------------------------------------------------------------
+  ProcessorRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: kata-205-ProcessorRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-205
+
+  # ---------------------------------------------------------------------------
+  # CloudWatch log group
+  # Declared explicitly so it is deleted with the stack instead of being left
+  # behind as an orphan when Lambda auto-creates it on first invocation.
+  # ---------------------------------------------------------------------------
+  ProcessorLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/kata-205-ProcessorFunction
+      RetentionInDays: 7
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-205
+
+  # ---------------------------------------------------------------------------
+  # Processor function
+  # Consumes batches of SQS messages and logs each one. Inline code is placed
+  # by CloudFormation in a file named 'index', so the handler is
+  # index.lambda_handler.
+  # ---------------------------------------------------------------------------
+  ProcessorFunction:
+    Type: AWS::Lambda::Function
+    DependsOn: ProcessorLogGroup
+    Properties:
+      FunctionName: kata-205-ProcessorFunction
+      Description: "CloudKata kata-205 — consumes messages from the processing queue"
+      Runtime: python3.12
+      Handler: index.lambda_handler
+      Role: !GetAtt ProcessorRole.Arn
+      Timeout: 30
+      Code:
+        ZipFile: |
+          def lambda_handler(event, context):
+              records = event.get("Records", [])
+              for record in records:
+                  message_id = record.get("messageId")
+                  body = record.get("body")
+                  print(f"kata-205 processed message {message_id}: {body}")
+              return {"processed": len(records)}
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-205
+
+  # ---------------------------------------------------------------------------
+  # Event source mapping
+  # Connects the processing queue to the function, pulling messages in batches.
+  #
+  # DependsOn ProcessorRole: the mapping cannot be created until the execution
+  # role's SQS permissions exist. The Ref to the function already orders the
+  # mapping after the function; the explicit role dependency guards against the
+  # IAM permission not being in place when Lambda validates the mapping.
+  # ---------------------------------------------------------------------------
+  QueueToFunctionMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    DependsOn: ProcessorRole
+    Properties:
+      EventSourceArn: !GetAtt ProcessingQueue.Arn
+      FunctionName: !Ref ProcessorFunction
+      BatchSize: 10
+      Enabled: true
+      Tags:
+        - Key: Project
+          Value: CloudKata
+        - Key: Kata
+          Value: kata-205
+
+# =============================================================================
+# Outputs
+# =============================================================================
+
+Outputs:
+
+  ProcessingQueueUrl:
+    Description: URL of the kata-205 processing queue
+    Value: !Ref ProcessingQueue
+
+  ProcessingQueueArn:
+    Description: ARN of the kata-205 processing queue
+    Value: !GetAtt ProcessingQueue.Arn
+
+  DeadLetterQueueUrl:
+    Description: URL of the kata-205 dead-letter queue
+    Value: !Ref DeadLetterQueue
+
+  DeadLetterQueueArn:
+    Description: ARN of the kata-205 dead-letter queue
+    Value: !GetAtt DeadLetterQueue.Arn
+
+  ProcessorFunctionName:
+    Description: Name of the kata-205 processor function
+    Value: !Ref ProcessorFunction
+
+  ProcessorFunctionArn:
+    Description: ARN of the kata-205 processor function
+    Value: !GetAtt ProcessorFunction.Arn
+
+  EventSourceMappingId:
+    Description: UUID of the event source mapping linking the queue to the function
+    Value: !Ref QueueToFunctionMapping
+
+  ExecutionRoleArn:
+    Description: ARN of the Lambda execution role
+    Value: !GetAtt ProcessorRole.Arn
+
+  ValidatorInstructions:
+    Description: How to validate this kata
+    Value: "Run validate.sh in AWS CloudShell to check all kata-205 requirements"

--- a/katas/kata-205-lambda-sqs-event-source/validate.sh
+++ b/katas/kata-205-lambda-sqs-event-source/validate.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+# =============================================================================
+# CloudKata — kata-205 Validator
+# kata:    kata-205
+# title:   Lambda + SQS: Event Source Mapping & Error Handling
+# author:  Faisal Akhtar
+# github:  https://github.com/fakhtar
+# =============================================================================
+#
+# Run this script in AWS CloudShell after building your kata infrastructure.
+#
+# Usage:
+#   sed -i 's/\r//' validate.sh
+#   chmod +x validate.sh
+#   ./validate.sh
+#
+# =============================================================================
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+PROCESSING_QUEUE_NAME="kata-205-ProcessingQueue"
+DLQ_NAME="kata-205-DeadLetterQueue"
+FUNCTION_NAME="kata-205-ProcessorFunction"
+SQS_MANAGED_POLICY_ARN="arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
+
+# ------------------------------------------------------------------------------
+# Helper functions
+# ------------------------------------------------------------------------------
+pass() {
+  echo "✅ PASS — $1"
+  PASS=$((PASS + 1))
+  TOTAL=$((TOTAL + 1))
+}
+
+fail() {
+  echo "❌ FAIL — $1: $2"
+  FAIL=$((FAIL + 1))
+  TOTAL=$((TOTAL + 1))
+}
+
+# ------------------------------------------------------------------------------
+# Header
+# ------------------------------------------------------------------------------
+echo ""
+echo "=================================================="
+echo " CloudKata Validator — kata-205"
+echo " Lambda + SQS: Event Source Mapping & Error Handling"
+echo "=================================================="
+echo ""
+
+# ------------------------------------------------------------------------------
+# Check 1 — Processing queue exists
+# ------------------------------------------------------------------------------
+echo "Checking processing queue..."
+PROCESSING_QUEUE_URL=$(aws sqs get-queue-url \
+  --queue-name "$PROCESSING_QUEUE_NAME" \
+  --query 'QueueUrl' \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+PROCESSING_QUEUE_ARN=""
+if [ "$PROCESSING_QUEUE_URL" != "NOT_FOUND" ] && [ "$PROCESSING_QUEUE_URL" != "None" ] && [ -n "$PROCESSING_QUEUE_URL" ]; then
+  PROCESSING_QUEUE_ARN=$(aws sqs get-queue-attributes \
+    --queue-url "$PROCESSING_QUEUE_URL" \
+    --attribute-names QueueArn \
+    --query 'Attributes.QueueArn' \
+    --output text 2>/dev/null || echo "")
+  pass "SQS queue '${PROCESSING_QUEUE_NAME}' exists"
+else
+  fail "SQS queue '${PROCESSING_QUEUE_NAME}'" "Queue not found — ensure a queue exists with the exact name '${PROCESSING_QUEUE_NAME}'"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 2 — Dead-letter queue exists
+# ------------------------------------------------------------------------------
+echo "Checking dead-letter queue..."
+DLQ_URL=$(aws sqs get-queue-url \
+  --queue-name "$DLQ_NAME" \
+  --query 'QueueUrl' \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+DLQ_ARN=""
+if [ "$DLQ_URL" != "NOT_FOUND" ] && [ "$DLQ_URL" != "None" ] && [ -n "$DLQ_URL" ]; then
+  DLQ_ARN=$(aws sqs get-queue-attributes \
+    --queue-url "$DLQ_URL" \
+    --attribute-names QueueArn \
+    --query 'Attributes.QueueArn' \
+    --output text 2>/dev/null || echo "")
+  pass "Dead-letter queue '${DLQ_NAME}' exists"
+else
+  fail "Dead-letter queue '${DLQ_NAME}'" "Queue not found — ensure a queue exists with the exact name '${DLQ_NAME}'"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 3 — Processing queue routes failed messages to the DLQ
+# ------------------------------------------------------------------------------
+echo "Checking redrive policy on processing queue..."
+if [ -n "$PROCESSING_QUEUE_ARN" ]; then
+  REDRIVE_POLICY=$(aws sqs get-queue-attributes \
+    --queue-url "$PROCESSING_QUEUE_URL" \
+    --attribute-names RedrivePolicy \
+    --query 'Attributes.RedrivePolicy' \
+    --output text 2>/dev/null || echo "None")
+
+  if [ "$REDRIVE_POLICY" = "None" ] || [ -z "$REDRIVE_POLICY" ]; then
+    fail "Redrive policy" "Processing queue has no redrive policy — configure it to send failed messages to '${DLQ_NAME}'"
+  else
+    DLT_ARN=$(echo "$REDRIVE_POLICY" | sed -nE 's/.*"deadLetterTargetArn"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p')
+    MAX_RECEIVE=$(echo "$REDRIVE_POLICY" | sed -nE 's/.*"maxReceiveCount"[[:space:]]*:[[:space:]]*"?([0-9]+)"?.*/\1/p')
+
+    TARGET_OK="no"
+    if [ -n "$DLQ_ARN" ] && [ "$DLT_ARN" = "$DLQ_ARN" ]; then
+      TARGET_OK="yes"
+    elif echo "$DLT_ARN" | grep -q "${DLQ_NAME}$"; then
+      TARGET_OK="yes"
+    fi
+
+    if [ "$TARGET_OK" = "yes" ] && [ -n "$MAX_RECEIVE" ] && [ "$MAX_RECEIVE" -ge 1 ] 2>/dev/null; then
+      pass "Processing queue routes failed messages to the dead-letter queue (maxReceiveCount: ${MAX_RECEIVE})"
+    elif [ "$TARGET_OK" != "yes" ]; then
+      fail "Redrive policy" "Redrive policy target '${DLT_ARN}' does not point to '${DLQ_NAME}'"
+    else
+      fail "Redrive policy" "Redrive policy is missing a valid maxReceiveCount"
+    fi
+  fi
+else
+  fail "Redrive policy" "Cannot check redrive policy — processing queue '${PROCESSING_QUEUE_NAME}' was not found"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 4 — Lambda function exists
+# ------------------------------------------------------------------------------
+echo "Checking Lambda function..."
+FUNCTION_ROLE_ARN=$(aws lambda get-function-configuration \
+  --function-name "$FUNCTION_NAME" \
+  --query 'Role' \
+  --output text 2>/dev/null || echo "NOT_FOUND")
+
+FUNCTION_EXISTS="no"
+if [ "$FUNCTION_ROLE_ARN" != "NOT_FOUND" ] && [ "$FUNCTION_ROLE_ARN" != "None" ] && [ -n "$FUNCTION_ROLE_ARN" ]; then
+  FUNCTION_EXISTS="yes"
+  pass "Lambda function '${FUNCTION_NAME}' exists"
+else
+  fail "Lambda function '${FUNCTION_NAME}'" "Function not found — ensure a function exists with the exact name '${FUNCTION_NAME}'"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 5 — Execution role permits consuming from the queue
+# (a) inspect the role's policies for SQS consume permission;
+#     fall back to an active event source mapping as proof.
+# ------------------------------------------------------------------------------
+echo "Checking function execution-role permissions..."
+if [ "$FUNCTION_EXISTS" = "yes" ]; then
+  ROLE_NAME="${FUNCTION_ROLE_ARN##*/}"
+  PERMISSION_FOUND="no"
+
+  # (a1) Known AWS managed policy attached?
+  ATTACHED_ARNS=$(aws iam list-attached-role-policies \
+    --role-name "$ROLE_NAME" \
+    --query 'AttachedPolicies[].PolicyArn' \
+    --output text 2>/dev/null || echo "")
+
+  if echo "$ATTACHED_ARNS" | grep -q "$SQS_MANAGED_POLICY_ARN"; then
+    PERMISSION_FOUND="yes"
+  fi
+
+  # (a2) Otherwise scan all policy documents (customer-managed + inline)
+  #      for an SQS receive grant.
+  if [ "$PERMISSION_FOUND" = "no" ] && [ -n "$ATTACHED_ARNS" ]; then
+    for ARN in $ATTACHED_ARNS; do
+      VERSION_ID=$(aws iam get-policy --policy-arn "$ARN" \
+        --query 'Policy.DefaultVersionId' --output text 2>/dev/null || echo "")
+      if [ -n "$VERSION_ID" ] && [ "$VERSION_ID" != "None" ]; then
+        DOC=$(aws iam get-policy-version --policy-arn "$ARN" --version-id "$VERSION_ID" \
+          --output json 2>/dev/null || echo "")
+        if echo "$DOC" | grep -Eiq 'receivemessage|sqs:\*|sqs%3a\*'; then
+          PERMISSION_FOUND="yes"
+          break
+        fi
+      fi
+    done
+  fi
+
+  if [ "$PERMISSION_FOUND" = "no" ]; then
+    INLINE_NAMES=$(aws iam list-role-policies \
+      --role-name "$ROLE_NAME" \
+      --query 'PolicyNames[]' \
+      --output text 2>/dev/null || echo "")
+    for PNAME in $INLINE_NAMES; do
+      DOC=$(aws iam get-role-policy --role-name "$ROLE_NAME" --policy-name "$PNAME" \
+        --output json 2>/dev/null || echo "")
+      if echo "$DOC" | grep -Eiq 'receivemessage|sqs:\*|sqs%3a\*'; then
+        PERMISSION_FOUND="yes"
+        break
+      fi
+    done
+  fi
+
+  if [ "$PERMISSION_FOUND" = "yes" ]; then
+    pass "Function's execution role permits consuming from the queue"
+  else
+    # Fallback: an active event source mapping implies working permissions.
+    FALLBACK_STATE="NONE"
+    if [ -n "$PROCESSING_QUEUE_ARN" ]; then
+      FALLBACK_STATE=$(aws lambda list-event-source-mappings \
+        --function-name "$FUNCTION_NAME" \
+        --event-source-arn "$PROCESSING_QUEUE_ARN" \
+        --query 'EventSourceMappings[0].State' \
+        --output text 2>/dev/null || echo "NONE")
+    fi
+    if [ "$FALLBACK_STATE" = "Enabled" ]; then
+      pass "Function's execution role permits consuming from the queue (inferred from active event source mapping)"
+    else
+      fail "Execution-role permissions" "No SQS receive permission found on the execution role — attach AWSLambdaSQSQueueExecutionRole or grant sqs:ReceiveMessage/DeleteMessage/GetQueueAttributes on '${PROCESSING_QUEUE_NAME}'"
+    fi
+  fi
+else
+  fail "Execution-role permissions" "Cannot check permissions — function '${FUNCTION_NAME}' was not found"
+fi
+
+# ------------------------------------------------------------------------------
+# Check 6 — Event source mapping connects the queue to the function and is enabled
+# ------------------------------------------------------------------------------
+echo "Checking event source mapping..."
+if [ "$FUNCTION_EXISTS" = "yes" ] && [ -n "$PROCESSING_QUEUE_ARN" ]; then
+  ESM_TEXT=$(aws lambda list-event-source-mappings \
+    --function-name "$FUNCTION_NAME" \
+    --event-source-arn "$PROCESSING_QUEUE_ARN" \
+    --query 'EventSourceMappings[0].[State,BatchSize]' \
+    --output text 2>/dev/null || echo "None")
+  read -r ESM_STATE ESM_BATCH <<< "$ESM_TEXT"
+
+  if [ -z "$ESM_STATE" ] || [ "$ESM_STATE" = "None" ]; then
+    fail "Event source mapping" "No event source mapping found linking '${PROCESSING_QUEUE_NAME}' to '${FUNCTION_NAME}'"
+  elif [ "$ESM_STATE" = "Enabled" ]; then
+    pass "Event source mapping connects the queue to the function and is enabled (batch size: ${ESM_BATCH})"
+  else
+    fail "Event source mapping" "Mapping exists but its state is '${ESM_STATE}', not 'Enabled' — enable the mapping"
+  fi
+else
+  fail "Event source mapping" "Cannot check mapping — function and/or processing queue was not found"
+fi
+
+# ------------------------------------------------------------------------------
+# Summary
+# ------------------------------------------------------------------------------
+echo ""
+echo "=================================================="
+if [ "$TOTAL" -gt 0 ]; then
+  PERCENTAGE=$(( PASS * 100 / TOTAL ))
+else
+  PERCENTAGE=0
+fi
+echo " Results: $PASS/$TOTAL checks passed ($PERCENTAGE%)"
+echo "=================================================="
+echo ""
+
+if [ "$PERCENTAGE" -eq 100 ]; then
+  echo " 🎉 Perfect score! All kata-205 requirements met."
+  echo ""
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+  echo " Review the failed checks above, fix your infrastructure,"
+  echo " and re-run this validator."
+  echo ""
+  exit 1
+fi


### PR DESCRIPTION
Add kata-205 (Breadth, Level 200, Services: Lambda + SQS): an event-driven worker pattern where a Lambda function drains an SQS queue via an event source mapping, with a dead-letter queue for messages that repeatedly fail processing.

Files:
- README.md    spec-driven requirements (6 requirements)
- validate.sh  CloudShell validator (6 checks), AWS CLI only
- solution.yml CloudFormation solution, passes validate.sh 100%
- HINTS.md     3-level progressive hints per requirement

Requirements map 1:1 to validator checks: processing queue, DLQ, redrive routing, function, execution-role permissions, and the event source mapping.

Validator design:
- Config-based throughout; no live send-and-consume check. SQS -> Lambda delivery is asynchronous, and a live end-to-end assertion would be timing-flaky (same failure mode retired in kata-204). An `Enabled` mapping state is treated as the proxy for "it runs".
- Check 5 (execution-role permissions) uses approach (a) with a fallback: first match the AWSLambdaSQSQueueExecutionRole managed policy by exact ARN, then scan customer-managed and inline policy documents for an SQS receive grant (matches ReceiveMessage, sqs:*, and URL-encoded sqs%3A* forms). Only if all inspection is inconclusive does it fall back to inferring permission from an Enabled event source mapping; the pass message states when the result was inferred rather than directly confirmed.
- Redrive check parses RedrivePolicy with sed (no jq dependency, per CONTRIBUTING's AWS-CLI-only rule); handles both numeric and quoted maxReceiveCount and either key order, and confirms the target resolves to kata-205-DeadLetterQueue.
- Checks degrade gracefully rather than hard-exiting: each dependent check guards on its prerequisite so a missing function still lets the queue/DLQ checks report (keeps checks independent per CONTRIBUTING).

Solution decisions:
- Single managed policy (AWSLambdaSQSQueueExecutionRole) covers both SQS consume and CloudWatch Logs, so no separate basic execution policy is needed and Check 5's primary path matches.
- Queue VisibilityTimeout (180s) is set to 6x the function Timeout (30s), per AWS guidance, so a message is not redelivered while still being processed and wrongly dead-lettered.
- EventSourceMapping DependsOn the execution role to avoid the "role not authorized to call ReceiveMessage" race on create; function DependsOn an explicit log group.
- Log group /aws/lambda/kata-205-ProcessorFunction is declared in the stack so teardown is clean instead of orphaning it.

Verification:
- bash -n clean; parsing paths (redrive sed, ARN->role-name, permission grep, ESM text split) unit-tested against sample data.
- cfn-lint 1.53.1 clean (exit 0); inline handler compiles.
- Resource names cross-checked between validate.sh and solution.yml.
- Live: deployed solution.yml and ran validate.sh -> 6/6 (100%).

Notes / limitations:
- Deploy requires CAPABILITY_NAMED_IAM (execution role is named).
- Validation is structural: it confirms the pipeline is wired to run, not that a specific message was processed end to end.
- BatchSize is reported but not asserted to a specific value; the check requires the mapping to exist and be Enabled.